### PR TITLE
Added procps, hostname, net-tools build_depends

### DIFF
--- a/hrpsys_ros_bridge/package.xml
+++ b/hrpsys_ros_bridge/package.xml
@@ -32,11 +32,14 @@
   <build_depend>diagnostic_msgs</build_depend>
   <build_depend>dynamic_reconfigure</build_depend>
   <build_depend>diagnostic_aggregator</build_depend>
+  <build_depend>hostname</build_depend>
   <build_depend>hrpsys</build_depend>
   <build_depend>hrpsys_tools</build_depend>
   <build_depend>image_transport</build_depend>
   <build_depend>pr2_controllers</build_depend> <!-- groovy does not have catkin pr2_controllers package -->
   <build_depend>mk</build_depend>
+  <build_depend>net-tools</build_depend>
+  <build_depend>procps</build_depend>
   <build_depend>python-rosdep</build_depend>
   <build_depend>robot_state_publisher</build_depend>
   <build_depend>rosbuild</build_depend>


### PR DESCRIPTION
These tools are used during building and testing. I believe that the packages are always installed in Ubuntu machines, but not necessarily on others (ie Fedora).

The deps were added to rosdep for this package in https://github.com/ros/rosdistro/commit/3b969695c28f331557b32244a3a51c8c5f8edf0e
