### PR TITLE
remove sed to comment out pr2_controllers (#410)

### DIFF
--- a/hrpsys_ros_bridge/catkin.cmake
+++ b/hrpsys_ros_bridge/catkin.cmake
@@ -88,14 +88,6 @@ rtmbuild_genbridge()
 # pr2_controller_msgs is not catkinized
 string(RANDOM _random_string)
 
-# Check ROS distro. since pr2_controller_msgs of groovy is not catkinized
-if($ENV{ROS_ROOT} MATCHES "/opt/ros/groovy/share/ros")
-  message("sed -i s@'<\\(.*_depend\\)>pr2_controllers</\\(.*_depend\\)>'@'<!-- \\1>pr2_controllers</\\2 -->'@g ${PROJECT_SOURCE_DIR}/package.xml")
-  execute_process(
-  COMMAND sh -c "sed -i s@'<\\(.*_depend\\)>pr2_controllers</\\(.*_depend\\)>'@'<!-- \\1>pr2_controllers</\\2 -->'@g ${PROJECT_SOURCE_DIR}/package.xml"
-  )
-endif($ENV{ROS_ROOT} MATCHES "/opt/ros/groovy/share/ros")
-
 rtmbuild_add_executable(HrpsysSeqStateROSBridge src/HrpsysSeqStateROSBridgeImpl.cpp src/HrpsysSeqStateROSBridge.cpp src/HrpsysSeqStateROSBridgeComp.cpp)
 rtmbuild_add_executable(ImageSensorROSBridge src/ImageSensorROSBridge.cpp src/ImageSensorROSBridgeComp.cpp)
 rtmbuild_add_executable(HrpsysJointTrajectoryBridge src/HrpsysJointTrajectoryBridge.cpp src/HrpsysJointTrajectoryBridgeComp.cpp)


### PR DESCRIPTION
I'm not sure if this works, but comment out pr2_controllrs from packge.xml may not necessary for groovy
- package.xml is used for rosdep install, currently we run rosdep as

```
rosdep install -r -n --from-paths src --ignore-src --rosdistro $ROS_DISTRO -y
```

so pr2_controllers is not found on rosdep system, but it will be ignored
(https://github.com/start-jsk/rtmros_common/blob/master/.travis.yml#L54)
(`-r                    Continue installing despite errors.`)
- when it compiles, it did not checks package.xml
- when it build dep package, they uses https://github.com/tork-a/rtmros_common-release/blob/patches/release/groovy/hrpsys_ros_bridge/0001-Commentout-a-dependency-on-pr2-catkin-package-that-d.patch, so it is commented out during build process
