### PR TITLE
set REALTIME=ture as default

### DIFF
--- a/hrpsys_ros_bridge/scripts/default_robot.launch.in
+++ b/hrpsys_ros_bridge/scripts/default_robot.launch.in
@@ -1,7 +1,7 @@
 <launch>
   <arg name="KILL_SERVERS" default="false" />
   <arg name="NOSIM" default="false" />
-  <arg name="REALTIME" default="false" />
+  <arg name="REALTIME" default="true" />
   <arg name="RUN_RVIZ" default="true" />
   <arg name="GUI" default="true" />
   <arg name="PROJECT_FILE" default="$(find @PROJECT_PKG_NAME@)/models/@ROBOT@_nosim.xml" if="$(arg NOSIM)"/>

--- a/hrpsys_ros_bridge/scripts/default_robot_startup.launch.in
+++ b/hrpsys_ros_bridge/scripts/default_robot_startup.launch.in
@@ -2,7 +2,7 @@
   <arg name="KILL_SERVERS" default="false" />
   <arg name="GUI" default="true" />
   <arg name="NOSIM" default="false" />
-  <arg name="REALTIME" default="false" />
+  <arg name="REALTIME" default="true" />
   <arg name="SIMULATOR_NAME" default="@ROBOT@(Robot)0" />
   <arg name="PROJECT_FILE" default="$(find @PROJECT_PKG_NAME@)/models/@ROBOT@_nosim.xml" if="$(arg NOSIM)"/>
   <arg name="PROJECT_FILE" default="$(find @PROJECT_PKG_NAME@)/models/@ROBOT@.xml" unless="$(arg NOSIM)"/>


### PR DESCRIPTION
set <arg name="REALTIME" default="true" />, so that hrpsys_ros_bridge did not consume cpu power

see https://github.com/start-jsk/rtmros_common/issues/408#issuecomment-40512477 for discussion
