### PR TITLE
Rotate sensor->localR 180[deg] because OpenHRP3 camera -Z axis equals to ROS camera Z axis

### DIFF
--- a/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridgeImpl.cpp
+++ b/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridgeImpl.cpp
@@ -137,7 +137,13 @@ RTC::ReturnCode_t HrpsysSeqStateROSBridgeImpl::onInitialize()
       hrp::Sensor* sensor = body->sensor(j, i);
       SensorInfo si;
       si.transform.setOrigin( tf::Vector3(sensor->localPos(0), sensor->localPos(1), sensor->localPos(2)) );
-      hrp::Vector3 rpy = hrp::rpyFromRot(sensor->localR);
+      hrp::Vector3 rpy;
+      if ( hrp::Sensor::VISION == sensor->type )
+        // Rotate sensor->localR 180[deg] because OpenHRP3 camera -Z axis equals to ROS camera Z axis
+        // http://www.openrtp.jp/openhrp3/jp/create_model.html
+        rpy = hrp::rpyFromRot(sensor->localR * hrp::rodrigues(hrp::Vector3(1,0,0), M_PI));
+      else
+        rpy = hrp::rpyFromRot(sensor->localR);
       si.transform.setRotation( tf::createQuaternionFromRPY(rpy(0), rpy(1), rpy(2)) );
       OpenHRP::LinkInfoSequence_var links = bodyinfo->links();
       for ( int k = 0; k < links->length(); k++ ) {


### PR DESCRIPTION
Rotate sensor->localR 180[deg] because OpenHRP3 camera -Z axis equals to.ROS camera Z axis
About OpenHRP3 camera definition:
  http://www.openrtp.jp/openhrp3/jp/create_model.html
