### PR TITLE
Add setting for unstable RTCs. Do not nothing by default.

### DIFF
--- a/hrpsys_ros_bridge/cmake/compile_robot_model.cmake
+++ b/hrpsys_ros_bridge/cmake/compile_robot_model.cmake
@@ -560,17 +560,30 @@ macro (generate_default_launch_eusinterface_files wrlfile project_pkg_name)
   if(NOT EXISTS ${hrpsys_ros_bridge_PACKAGE_PATH}/scripts)
     message(FATAL_ERROR "hrpsys_ros_bridge_PACKAGE_PATH could not found")
   endif()
+
+  # generate files
   set(${_sname}_generated_launch_euslisp_files)
+  #   generate hrpsys_config.py to use unstable RTCs
+  if ("${ARGV3}" STREQUAL "--use-unstable-hrpsys-config")
+    configure_file(${hrpsys_ros_bridge_PACKAGE_PATH}/scripts/default_unstable_hrpsys_config.py.in ${PROJECT_SOURCE_DIR}/scripts/${_sname}_unstable_hrpsys_config.py)
+    list(APPEND ${_sname}_generated_launch_euslisp_files ${PROJECT_SOURCE_DIR}/scripts/${_sname}_unstable_hrpsys_config.py)
+    set(ROSBRIDGE_ARGS "    <arg name=\"USE_WALKING\" default=\"true\" />\n    <arg name=\"USE_IMPEDANCECONTROLLER\" default=\"true\" />")
+    set(STARTUP_ARGS "    <arg name=\"HRPSYS_PY_PKG\" default=\"${PROJECT_PKG_NAME}\" />\n    <arg name=\"HRPSYS_PY_NAME\" default=\"${robot}_unstable_hrpsys_config.py\" />")
+  endif()
+  #  generate startup.launch
   configure_file(${hrpsys_ros_bridge_PACKAGE_PATH}/scripts/default_robot_startup.launch.in ${PROJECT_SOURCE_DIR}/launch/${_sname}_startup.launch)
   list(APPEND ${_sname}_generated_launch_euslisp_files ${PROJECT_SOURCE_DIR}/launch/${_sname}_startup.launch)
+  #  generate ros_bridge.launch
   configure_file(${hrpsys_ros_bridge_PACKAGE_PATH}/scripts/default_robot_ros_bridge.launch.in ${PROJECT_SOURCE_DIR}/launch/${_sname}_ros_bridge.launch)
   list(APPEND ${_sname}_generated_launch_euslisp_files ${PROJECT_SOURCE_DIR}/launch/${_sname}_ros_bridge.launch)
+  #  generate toplevel launch which includes ros_bridge.launch and startup.launch
   if (NOT "${ARGV3}" STREQUAL "--no-toplevel-launch")
     configure_file(${hrpsys_ros_bridge_PACKAGE_PATH}/scripts/default_robot.launch.in ${PROJECT_SOURCE_DIR}/launch/${_sname}.launch)
     configure_file(${hrpsys_ros_bridge_PACKAGE_PATH}/scripts/default_robot_nosim.launch.in ${PROJECT_SOURCE_DIR}/launch/${_sname}_nosim.launch)
     list(APPEND ${_sname}_generated_launch_euslisp_files ${PROJECT_SOURCE_DIR}/launch/${_sname}.launch)
     list(APPEND ${_sname}_generated_launch_euslisp_files ${PROJECT_SOURCE_DIR}/launch/${_sname}_nosim.launch)
   endif()
+  #  generate euslisp robot-interface file
   if (NOT "${ARGV3}" STREQUAL "--no-euslisp")
     configure_file(${hrpsys_ros_bridge_PACKAGE_PATH}/scripts/default-robot-interface.l.in ${PROJECT_SOURCE_DIR}/build/${_sname}-interface.l)
     list(APPEND ${_sname}_generated_launch_euslisp_files ${PROJECT_SOURCE_DIR}/build/${_sname}-interface.l)

--- a/hrpsys_ros_bridge/scripts/default_robot_ros_bridge.launch.in
+++ b/hrpsys_ros_bridge/scripts/default_robot_ros_bridge.launch.in
@@ -10,6 +10,7 @@
     <arg name="MODEL_FILE" value="@MODEL_FILE@" />
     <arg name="COLLADA_FILE" value="$(find @PROJECT_PKG_NAME@)/models/@ROBOT@.dae" />
     <arg name="corbaport" default="$(arg corbaport)" />
+@ROSBRIDGE_ARGS@
   </include>
 
   <group if="$(arg RUN_RVIZ)" >

--- a/hrpsys_ros_bridge/scripts/default_robot_startup.launch.in
+++ b/hrpsys_ros_bridge/scripts/default_robot_startup.launch.in
@@ -17,5 +17,6 @@
     <arg name="REALTIME" default="$(arg REALTIME)" />
     <arg name="corbaport" default="$(arg corbaport)" />
     <arg name="GUI" default="$(arg GUI)" />
+@STARTUP_ARGS@
   </include>
 </launch>

--- a/hrpsys_ros_bridge/scripts/default_unstable_hrpsys_config.py.in
+++ b/hrpsys_ros_bridge/scripts/default_unstable_hrpsys_config.py.in
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+
+pkg = 'hrpsys'
+import imp
+try:
+    imp.find_module(pkg)
+except:
+    import roslib
+    roslib.load_manifest(pkg)
+
+from hrpsys.hrpsys_config import *
+import OpenHRP
+
+class @ROBOT@Configurator(HrpsysConfigurator):
+    def getRTCList (self):
+        return self.getRTCListUnstable()
+
+if __name__ == '__main__':
+    hcf = @ROBOT@Configurator()
+    if len(sys.argv) > 2 :
+        hcf.init(sys.argv[1], sys.argv[2])
+    elif len(sys.argv) > 1 :
+        hcf.init(sys.argv[1])
+    else :
+        hcf.init()


### PR DESCRIPTION
Add generation of hrpsys_config for robots using unstable RTCs. 
Add configuration for unstable RTCs in cmake. 
By default, this commit do not nothing, so there will be no side effect for robots only using Stable RTCs.
This commit is based on the discussion about unstable RTC and getRTCListUnstable[1]. 

[1] https://github.com/fkanehiro/hrpsys-base/issues/210
