### PR TITLE
Update imu euslisp methods

### DIFF
--- a/hrpsys_ros_bridge/euslisp/datalogger-log-parser.l
+++ b/hrpsys_ros_bridge/euslisp/datalogger-log-parser.l
@@ -127,11 +127,27 @@
            (send f :name)
            (send (send self :parser-list (format nil "~A_~A" robothardware-name (send f :name))) :read-state)
            ))
-   (dolist (i (send robot :imu-sensors))
-     (send self :set-robot-state1
-           (send i :name)
-           (send (send self :parser-list (format nil "~A_~A" robothardware-name (send i :name))) :read-state)
-           ))
+   ;; (dolist (i (send robot :imu-sensors))
+   ;;   (send self :set-robot-state1
+   ;;         (send i :name)
+   ;;         (send (send self :parser-list (format nil "~A_~A" robothardware-name (send i :name))) :read-state)
+   ;;         ))
+   (send self :set-robot-state1
+         :imu
+         (let* ((rpy (send (send self :parser-list "kf_rpy") :read-state))
+                (qt (ros::rot->tf-quaternion (rpy-matrix (elt rpy 2) (elt rpy 1) (elt rpy 0)))))
+           (instance* sensor_msgs::Imu :init
+                      :orientation qt
+                      (append
+                       (if (send robot :imu-sensor "gsensor")
+                           (list :linear_acceleration
+                                 (let ((acc (send (send self :parser-list (format nil "~A_~A" robothardware-name "gsensor")) :read-state)))
+                                   (instance geometry_msgs::Vector3 :init :x (elt acc 0) :y (elt acc 1) :z (elt acc 2)))))
+                       (if (send robot :imu-sensor "gyrometer")
+                           (list :angular_velocity
+                                 (let ((gyro (send (send self :parser-list (format nil "~A_~A" robothardware-name "gyrometer")) :read-state)))
+                                   (instance geometry_msgs::Vector3 :init :x (elt gyro 0) :y (elt gyro 1) :z (elt gyro 2))))))
+                      )))
    )
   ;; overwrite
   (:reference-vector () (cdr (assoc :reference-vector robot-state)))

--- a/hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l
+++ b/hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l
@@ -25,7 +25,8 @@
              (send-all (send robot :force-sensors) :name))
      (ros::subscribe "/zmp" geometry_msgs::PointStamped
                      #'send self :rtmros-zmp-callback :groupname groupname)
-
+     (ros::subscribe "/imu" sensor_msgs::Imu
+                     #'send self :rtmros-imu-callback :groupname groupname)
      ))
   (:rtmros-motor-states-callback
    (msg)
@@ -35,6 +36,9 @@
    (msg)
    (let ((p (send msg :point)))
      (send self :set-robot-state1 :zmp (float-vector (send p :x) (send p :y) (send p :z)))))
+  (:rtmros-imu-callback
+   (msg)
+   (send self :set-robot-state1 :imu msg))
   (:temperature-vector () (cdr (assoc :temperature robot-state)))
   (:motor-extra-data
    ()
@@ -173,12 +177,19 @@
   (:update-robot-state
    ()
    (send-super :update-robot-state)
-   (let ((imucoords (send *tfl* :lookup-transform "/imu_floor" (format nil "/~a" (send (car (send robot :links)) :name)) (ros::time))))
-     (if imucoords (send robot :newcoords imucoords))
-     ))
+   (let ((imucoords (make-coords :rot (ros::tf-quaternion->rot (send (cdr (assoc :imu robot-state)) :orientation)))))
+     (if imucoords (send robot :move-coords imucoords (car (send robot :imu-sensors))))))
   (:imucoords
    ()
    (send robot :copy-worldcoords))
+  (:accel-vector
+   ()
+   (let ((acc (send (cdr (assoc :imu robot-state)) :linear_acceleration)))
+     (float-vector (send acc :x) (send acc :y) (send acc :z))))
+  (:gyro-vector
+   ()
+   (let ((gyro (send (cdr (assoc :imu robot-state)) :angular_velocity)))
+     (float-vector (send gyro :x) (send gyro :y) (send gyro :z))))
   (:state
     (&rest args)
     (case (car args)


### PR DESCRIPTION
(rtm-ros-robot-interface.l, datalogger-log-parser.l)
Update imu euslisp methods 
We should use /imu instead of tf according to https://github.com/start-jsk/rtmros_common/pull/477
