### PR TITLE
Add argument to use Unstable RTC

### DIFF
--- a/hrpsys_ros_bridge/cmake/compile_robot_model.cmake
+++ b/hrpsys_ros_bridge/cmake/compile_robot_model.cmake
@@ -570,10 +570,8 @@ macro (generate_default_launch_eusinterface_files wrlfile project_pkg_name)
   set(${_sname}_generated_launch_euslisp_files)
   #   generate hrpsys_config.py to use unstable RTCs
   if ("${ARGV3}" STREQUAL "--use-unstable-hrpsys-config")
-    configure_file(${hrpsys_ros_bridge_PACKAGE_PATH}/scripts/default_unstable_hrpsys_config.py.in ${PROJECT_SOURCE_DIR}/scripts/${_sname}_unstable_hrpsys_config.py)
-    list(APPEND ${_sname}_generated_launch_euslisp_files ${PROJECT_SOURCE_DIR}/scripts/${_sname}_unstable_hrpsys_config.py)
     set(ROSBRIDGE_ARGS "    <arg name=\"USE_WALKING\" default=\"true\" />\n    <arg name=\"USE_IMPEDANCECONTROLLER\" default=\"true\" />")
-    set(STARTUP_ARGS "    <arg name=\"HRPSYS_PY_PKG\" default=\"${PROJECT_PKG_NAME}\" />\n    <arg name=\"HRPSYS_PY_NAME\" default=\"${robot}_unstable_hrpsys_config.py\" />")
+    set(STARTUP_ARGS "    <arg name=\"HRPSYS_PY_ARGS\" default=\"--use-unstable-rtc\" />")
   endif()
   #  generate startup.launch
   configure_file(${hrpsys_ros_bridge_PACKAGE_PATH}/scripts/default_robot_startup.launch.in ${PROJECT_SOURCE_DIR}/launch/${_sname}_startup.launch)

--- a/hrpsys_tools/launch/hrpsys.launch
+++ b/hrpsys_tools/launch/hrpsys.launch
@@ -82,6 +82,7 @@
   <!-- BEGIN:hrpsys.py setting -->
   <arg name="HRPSYS_PY_PKG" default="hrpsys_tools"/>
   <arg name="HRPSYS_PY_NAME" default="hrpsys_tools_config.py"/>
+  <arg name="HRPSYS_PY_ARGS" default='' />
   <arg name="LAUNCH_HRPSYSPY" default="true" />
   <!-- END:hrpsys.py setting -->
 
@@ -110,7 +111,7 @@
 
   <group if="$(arg LAUNCH_HRPSYSPY)">
     <node name="hrpsys_py" pkg="$(arg HRPSYS_PY_PKG)" type="$(arg HRPSYS_PY_NAME)" output="screen"
-          args='$(arg SIMULATOR_NAME) $(arg MODEL_FILE) $(arg omniorb_args)'
+          args='$(arg HRPSYS_PY_ARGS) $(arg SIMULATOR_NAME) $(arg MODEL_FILE) $(arg omniorb_args)'
           launch-prefix="$(arg PY_LAUNCH_PREFIX)" />
   </group>
 

--- a/hrpsys_tools/scripts/hrpsys_tools_config.py
+++ b/hrpsys_tools/scripts/hrpsys_tools_config.py
@@ -15,6 +15,7 @@ if __name__ == '__main__':
     parser.add_argument('--port', help='corba name server port number')
     parser.add_argument('-i', help='interactive mode',  action='store_true')
     parser.add_argument('-c', help='execute command',  nargs='*')
+    parser.add_argument('--use-unstable-rtc', help='use unstable rtc', action='store_true')
     args, unknown = parser.parse_known_args()
 
     if args.i: # interactive
@@ -29,6 +30,8 @@ if __name__ == '__main__':
 
     # ipython ./hrpsys_tools_config.py -i -- --port 2809
     hcf = HrpsysConfigurator()
+    if args.use_unstable_rtc: # use Unstable RTC
+        hcf.getRTCList = hcf.getRTCListUnstable; sys.argv = [sys.argv[0]] + sys.argv[2:]
     if args.i or '__IPYTHON__' in vars(__builtins__):
         hcf.waitForModelLoader()
         if len(sys.argv) > 1 and not sys.argv[1].startswith('-'):


### PR DESCRIPTION
(compile_robot_model.cmake, hrpsys.launch, hrpsys_tools_config.py)
Add argument to use Unstable RTC List and configure it from cmake discussed in https://github.com/start-jsk/rtmros_gazebo/pull/61
