### PR TITLE
Check whether robot state contains imu information

### DIFF
--- a/hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l
+++ b/hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l
@@ -177,8 +177,9 @@
   (:update-robot-state
    ()
    (send-super :update-robot-state)
-   (let ((imucoords (make-coords :rot (ros::tf-quaternion->rot (send (cdr (assoc :imu robot-state)) :orientation)))))
-     (if imucoords (send robot :move-coords imucoords (car (send robot :imu-sensors))))))
+   (when (assoc :imu robot-state)
+     (let ((imucoords (make-coords :rot (ros::tf-quaternion->rot (send (cdr (assoc :imu robot-state)) :orientation)))))
+       (if imucoords (send robot :move-coords imucoords (car (send robot :imu-sensors)))))))
   (:imucoords
    ()
    (send robot :copy-worldcoords))


### PR DESCRIPTION
This modification is necessary when using kinematics simulator.
https://github.com/start-jsk/rtmros_tutorials/issues/67
