### PR TITLE
Fix end-effector name

### DIFF
--- a/hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l
+++ b/hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l
@@ -465,7 +465,7 @@
   (:start-auto-balancer
    (&key (limbs '(:rleg :lleg)))
    (send self :autobalancerservice_startAutoBalancer
-         :limbs (mapcar #'(lambda (x) (format nil "~A" x)) limbs)))
+         :limbs (mapcar #'(lambda (x) (format nil "~A" (string-downcase x))) limbs)))
   (:stop-auto-balancer () (send self :autobalancerservice_stopAutoBalancer))
   (:go-pos-no-wait
    (xx yy th)


### PR DESCRIPTION
(rtm-ros-robot-interface) : Fix end-effector name (without colon) according to https://github.com/fkanehiro/hrpsys-base/pull/301
