### PR TITLE
fix #523, use catkin_make -C to change direcotry

### DIFF
--- a/hrpsys_ros_bridge/catkin.cmake
+++ b/hrpsys_ros_bridge/catkin.cmake
@@ -12,7 +12,7 @@ if(NOT pr2_controllers_msgs_FOUND)
   download_pr2_controllers_msgs(hydro-devel)
   # catkin_make
   # rosmake pr2_controllers_msgs
-  execute_process(COMMAND cmake -E chdir ${CMAKE_SOURCE_DIR}/../ catkin_make --build /tmp/pr2_controllers --source ${PROJECT_SOURCE_DIR}/../pr2_controllers_msgs --pkg pr2_controllers_msgs OUTPUT_VARIABLE _compile_output RESULT_VARIABLE _compile_failed)
+  execute_process(COMMAND cmake -E chdir ${CMAKE_SOURCE_DIR}/../ catkin_make -C ${CMAKE_SOURCE_DIR}/../ --build /tmp/pr2_controllers --source ${PROJECT_SOURCE_DIR}/../pr2_controllers_msgs --pkg pr2_controllers_msgs OUTPUT_VARIABLE _compile_output RESULT_VARIABLE _compile_failed)
   message("compile pr2_controllers_msgs ${_compile_output}")
   if (_compile_failed)
     message(FATAL_ERROR "compile pr2_controllers_msgs failed : ${_compile_failed}")


### PR DESCRIPTION
something has changed in catkin_make around
https://github.com/ros/catkin/commit/6f9d5d3746fb362d08b2c04b0a69c1451cfcd7a6, 
https://github.com/ros/catkin/commit/d24e7fdf63f35a8ef06c0c4b95b648969b8f1152

it ues '.' to get current path so that `cmake -E chdir` works, but now it uses `PWD` and it changed behavior

```
$ cmake -E chdir /tmp python -c "import os; print os.getenv('PWD'); print os.path.abspath('.');"
/home/k-okada/ros/hydro/src/rtm-ros-robotics/rtmros_common/hrpsys_ros_bridge
/tmp

```
