### PR TITLE
set use_deb=false for groovy as allow failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,10 @@ env:
   - ROS_DISTRO=hydro  ROSWS=wstool BUILDER=catkin    USE_DEB=false
   - TEST_TYPE=work_with_downstream  TEST_PACKAGE=hironx-ros-bridge ROS_DISTRO=hydro
   - TEST_TYPE=work_with_315_1_10    TEST_PACKAGE=hironx-ros-bridge ROS_DISTRO=hydro
+matrix:
+  allow_failures:
+  - env: ROS_DISTRO=groovy ROSWS=rosws  BUILDER=rosbuild  USE_DEB=false
+  - env: ROS_DISTRO=groovy ROSWS=wstool BUILDER=catkin    USE_DEB=false
 notifications:
   email:
     recipients:


### PR DESCRIPTION
recently use_dab=falase for groovy/catkin never pass the test due to lack of memory, so set these env as allow_failure
