### PR TITLE
do not print a leading colon of :rarm

### DIFF
--- a/hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l
+++ b/hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l
@@ -713,7 +713,7 @@
   (format t "end_effectors:")
   (dolist (l '(:rarm :larm :rleg :lleg))
     (let ((rl (send (send (send rb l :root-link) :parent) :joint)))
-      (format t " ~A,~A,~A," l (send (send (send rb l :end-coords :parent) :joint) :name) (if rl (send rl :name) "WAIST"))
+      (format t " ~A,~A,~A," (string-downcase (string l)) (send (send (send rb l :end-coords :parent) :joint) :name) (if rl (send rl :name) "WAIST"))
       (let* ((dif (send (send rb l :end-coords :parent) :transformation (send rb l :end-coords)))
              (wp (scale 1e-3 (send dif :worldpos))) ;; [mm] -> [m]
              (wr (normalize-vector (matrix-log (send dif :worldrot))))


### PR DESCRIPTION
fix a useful function `print-end-effector-parameter-conf-from-robot`, which automatically generates information about end-effectors in Robot.conf (e.g. https://github.com/start-jsk/rtmros_tutorials/blob/master/hrpsys_ros_bridge_tutorials/catkin.cmake#L203 ), in order not to print a leading `:` of `:rarm`, `:larm`, `:rleg` and `:lleg`.

I heard that the colon was removed by hand before this PR.
