### PR TITLE
Update rtmbuild_init to specify dependency of generate_messages and add new service interface to HrpsysSeqStateROSBridge to specify transformation for each sensor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,5 +30,5 @@ notifications:
     on_success: always #[always|never|change] # default: change
     on_failure: always #[always|never|change] # default: always
 script:
-  - export ROS_PARALLEL_JOBS="-j4 -l4"
+  - export ROS_PARALLEL_JOBS="-j2 -l2"
   - if [ "${TEST_TYPE}" == "" ] ; then source .travis/travis.sh; else source ./.travis_test.sh ; fi

--- a/hrpsys_ros_bridge/catkin.cmake
+++ b/hrpsys_ros_bridge/catkin.cmake
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(hrpsys_ros_bridge)
 
 # call catkin depends
-find_package(catkin REQUIRED COMPONENTS rtmbuild roscpp rostest sensor_msgs robot_state_publisher actionlib control_msgs tf camera_info_manager hrpsys_tools image_transport dynamic_reconfigure hrpsys nav_msgs) # pr2_controllers_msgs robot_monitor
+find_package(catkin REQUIRED COMPONENTS rtmbuild roscpp rostest sensor_msgs robot_state_publisher actionlib control_msgs tf camera_info_manager hrpsys_tools image_transport dynamic_reconfigure hrpsys nav_msgs geometry_msgs) # pr2_controllers_msgs robot_monitor geometry_msgs
 catkin_python_setup()
 
 # download pr2_controllers_msgs for git
@@ -66,9 +66,9 @@ unset(hrpsys_LIBRARIES CACHE) # remove not to add hrpsys_LIBRARIES to hrpsys_ros
 
 # define add_message_files before rtmbuild_init
 add_message_files(FILES MotorStates.msg)
-
+add_service_files(FILES SetSensorTransformation.srv)
 # initialize rtmbuild
-rtmbuild_init()
+rtmbuild_init(geometry_msgs)
 
 # call catkin_package, after rtmbuild_init, before rtmbuild_gen*
 catkin_package(

--- a/hrpsys_ros_bridge/manifest.xml
+++ b/hrpsys_ros_bridge/manifest.xml
@@ -39,6 +39,7 @@ hrpsys_ros_bridge.launch : hrpsys and ROS bridge software core launch script, th
     <depend package="geometry_msgs" />
 
   <depend package="control_msgs"/>
+  <depend package="geometry_msgs" />
   <depend package="tf" />
   <depend package="rosnode" /> <!-- actionlib depeds on ronsode as test_depends -->
 

--- a/hrpsys_ros_bridge/package.xml
+++ b/hrpsys_ros_bridge/package.xml
@@ -60,7 +60,8 @@
   <build_depend>subversion</build_depend>
   <build_depend>tf</build_depend>
   <build_depend>visualization_msgs</build_depend>
-  
+  <build_depend>geometry_msgs</build_depend>
+
   <run_depend>actionlib</run_depend>
   <run_depend>camera_info_manager</run_depend>
   <run_depend>collada_urdf</run_depend>
@@ -88,7 +89,7 @@
   <run_depend>sensor_msgs</run_depend>
   <run_depend>tf</run_depend>
   <run_depend>visualization_msgs</run_depend>
-
+  <run_depend>geometry_msgs</run_depend>
   <!-- <test_depend>hrpsys</test_depend> -->
   <!-- <test_depend>hrpsys_tools</test_depend> -->
   <!-- <test_depend>openrtm_tools</test_depend> -->

--- a/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.h
+++ b/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.h
@@ -26,6 +26,7 @@
 #include "hrpsys_ros_bridge/MotorStates.h"
 #include "diagnostic_msgs/DiagnosticArray.h"
 #include "sensor_msgs/Imu.h"
+#include "hrpsys_ros_bridge/SetSensorTransformation.h"
 
 extern const char* hrpsysseqstaterosbridgeimpl_spec[];
 
@@ -46,8 +47,9 @@ class HrpsysSeqStateROSBridge  : public HrpsysSeqStateROSBridgeImpl
   void onFollowJointTrajectoryActionPreempt();
   void onTrajectoryCommandCB(const trajectory_msgs::JointTrajectoryConstPtr& msg);
   bool sendMsg (dynamic_reconfigure::Reconfigure::Request &req,
-		dynamic_reconfigure::Reconfigure::Response &res);
-
+                dynamic_reconfigure::Reconfigure::Response &res);
+  bool setSensorTransformation(hrpsys_ros_bridge::SetSensorTransformation::Request& req,
+                               hrpsys_ros_bridge::SetSensorTransformation::Response& res);
  private:
   ros::NodeHandle nh;
   ros::Publisher joint_state_pub, joint_controller_state_pub, mot_states_pub, diagnostics_pub, clock_pub, zmp_pub, odom_pub, imu_pub;
@@ -56,6 +58,7 @@ class HrpsysSeqStateROSBridge  : public HrpsysSeqStateROSBridgeImpl
   actionlib::SimpleActionServer<pr2_controllers_msgs::JointTrajectoryAction> joint_trajectory_server;
   actionlib::SimpleActionServer<control_msgs::FollowJointTrajectoryAction> follow_joint_trajectory_server;
   ros::ServiceServer sendmsg_srv;
+  ros::ServiceServer set_sensor_transformation_srv;
   bool interpolationp, use_sim_time, use_hrpsys_time;
 
   tf::TransformBroadcaster br;
@@ -67,6 +70,9 @@ class HrpsysSeqStateROSBridge  : public HrpsysSeqStateROSBridgeImpl
   std::string rootlink_name;
 
   ros::Subscriber clock_sub;
+
+  std::map<std::string, geometry_msgs::Transform> sensor_transformations;
+  boost::mutex sensor_transformation_mutex;
 
   nav_msgs::Odometry prev_odom;
   bool prev_odom_acquired;

--- a/hrpsys_ros_bridge/srv/SetSensorTransformation.srv
+++ b/hrpsys_ros_bridge/srv/SetSensorTransformation.srv
@@ -1,0 +1,3 @@
+string sensor_name
+geometry_msgs/Transform transform
+---

--- a/rtmbuild/cmake/rtmbuild.cmake
+++ b/rtmbuild/cmake/rtmbuild.cmake
@@ -34,6 +34,7 @@ endif()
 # setup global variables
 #
 macro(rtmbuild_init)
+  set(_extra_message_dependencies ${ARGV0})
   if(NOT use_catkin) ## rosbuild_init cleans all variable so we first defind project and call rosbuild_init later with ROSBUILD_DONT_REDEFINE_PROJECT=TRUE
     get_filename_component(_project ${CMAKE_SOURCE_DIR} NAME)
     project(${_project})
@@ -125,7 +126,7 @@ macro(rtmbuild_init)
   if(use_catkin)
     add_message_files(DIRECTORY msg FILES "${${PROJECT_NAME}_autogen_msg_files}")
     add_service_files(DIRECTORY srv FILES "${${PROJECT_NAME}_autogen_srv_files}")
-    generate_messages(DEPENDENCIES std_msgs)
+    generate_messages(DEPENDENCIES std_msgs ${_extra_message_dependencies})
   else()
     rosbuild_genmsg()
     rosbuild_gensrv()


### PR DESCRIPTION
For calibration:
- update rtmbuild to specify dependency of message_generation
- add SetSensorTransformation.srv to hrpsys_ros_bridge
- add set_sensor_transformation service to HrpsysSeqStateROSBridge to overwrite sensor transformation information of VRML.
