### PR TITLE
Add ~publish_sensor_tf param

### DIFF
--- a/hrpsys_ros_bridge/launch/hrpsys_ros_bridge.launch
+++ b/hrpsys_ros_bridge/launch/hrpsys_ros_bridge.launch
@@ -20,6 +20,7 @@
   <arg name="USE_SOFTERRORLIMIT" default="true" />
   <arg name="USE_TORQUEFILTER" default="false" />
   <arg name="USE_IMAGESENSOR" default="false" />
+  <arg name="PUBLISH_SENSOR_TF" default="true" />
   <!--
       roslaunch hrpsys_ros_bridge sample.launch nameserver:=192.168.1.1
   -->
@@ -38,7 +39,9 @@
         pkg  = "hrpsys_ros_bridge"
         type = "HrpsysSeqStateROSBridge"
         args = "$(arg openrtm_args) -o model:$(arg MODEL_FILE) $(arg CONF_FILE_ARG)"
-        output = "$(arg OUTPUT)" />
+        output = "$(arg OUTPUT)">
+    <param name="publish_sensor_tf" value="$(arg PUBLISH_SENSOR_TF)" />
+  </node>
   <node name = "HrpsysJointTrajectoryBridge"
         pkg  = "hrpsys_ros_bridge"
         type = "HrpsysJointTrajectoryBridge"

--- a/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.cpp
+++ b/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.cpp
@@ -37,6 +37,9 @@ HrpsysSeqStateROSBridge::HrpsysSeqStateROSBridge(RTC::Manager* manager) :
   HrpsysSeqStateROSBridgeImpl(manager), follow_action_initialized(false)
 {
   // ros
+  ros::NodeHandle pnh("~");
+  pnh.param("publish_sensor_transforms", publish_sensor_transforms, true);
+  
   joint_trajectory_server.registerGoalCallback(boost::bind(&HrpsysSeqStateROSBridge::onJointTrajectoryActionGoal, this));
   joint_trajectory_server.registerPreemptCallback(boost::bind(&HrpsysSeqStateROSBridge::onJointTrajectoryActionPreempt, this));
   follow_joint_trajectory_server.registerGoalCallback(boost::bind(&HrpsysSeqStateROSBridge::onFollowJointTrajectoryActionGoal, this));
@@ -401,7 +404,7 @@ RTC::ReturnCode_t HrpsysSeqStateROSBridge::onExecute(RTC::UniqueId ec_id)
     }
     joint_state_pub.publish(joint_state);
     // sensors publish
-    {
+    if (publish_sensor_transforms) {
       boost::mutex::scoped_lock lock(sensor_transformation_mutex);
       std::map<std::string, SensorInfo>::const_iterator its = sensor_info.begin();
       while ( its != sensor_info.end() ) {

--- a/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.h
+++ b/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.h
@@ -60,7 +60,7 @@ class HrpsysSeqStateROSBridge  : public HrpsysSeqStateROSBridgeImpl
   ros::ServiceServer sendmsg_srv;
   ros::ServiceServer set_sensor_transformation_srv;
   bool interpolationp, use_sim_time, use_hrpsys_time;
-
+  bool publish_sensor_transforms;
   tf::TransformBroadcaster br;
 
   coil::Mutex m_mutex;


### PR DESCRIPTION
- Add parameter ~publish_sensor_tf to HrpsysSeqStateROSBridge to toggle publishing tf frames of the sensors
- add PUBLISH_SENSOR_TF argument to hrpsys_ros_bridge.launch
