### PR TITLE
Publish reference wrench from StateHolder wrench data ports

### DIFF
--- a/hrpsys_ros_bridge/scripts/sensor_ros_bridge_connect.py
+++ b/hrpsys_ros_bridge/scripts/sensor_ros_bridge_connect.py
@@ -15,7 +15,7 @@ import OpenHRP
 
 program_name = '[sensor_ros_bridge_connect.py] '
 
-def connecSensorRosBridgePort(url, rh, bridge, vs, rmfo):
+def connecSensorRosBridgePort(url, rh, bridge, vs, rmfo, sh):
     for sen in hcf.getSensors(url):
         if sen.type in ['Acceleration', 'RateGyro', 'Force']:
             if rh.port(sen.name) != None: # check existence of sensor ;; currently original HRP4C.xml has different naming rule of gsensor and gyrometer
@@ -24,6 +24,9 @@ def connecSensorRosBridgePort(url, rh, bridge, vs, rmfo):
                 if sen.type == 'Force' and rmfo != None:
                     print program_name, "connect ", sen.name, rmfo.port("off_" + sen.name).get_port_profile().name, bridge.port("off_" + sen.name).get_port_profile().name
                     connectPorts(rmfo.port("off_" + sen.name), bridge.port("off_" + sen.name), "new") # for abs forces
+                if sen.type == 'Force' and sh.port(sen.name+"Out") and bridge.port("ref_" + sen.name):
+                    print program_name, "connect ", sen.name, sh.port(sen.name+"Out").get_port_profile().name, bridge.port("ref_" + sen.name).get_port_profile().name
+                    connectPorts(sh.port(sen.name+"Out"), bridge.port("ref_" + sen.name), "new") # for reference forces
         else:
             continue
     if vs != None:
@@ -41,7 +44,8 @@ def initSensorRosBridgeConnection(url, simulator_name, rosbridge_name, managerho
         print program_name, " wait for ", rosbridge_name, " : ",bridge
     vs=rtm.findRTC('vs')
     rmfo=rtm.findRTC('rmfo')
-    connecSensorRosBridgePort(url, hcf.rh, bridge, vs, rmfo)
+    sh=rtm.findRTC('sh')
+    connecSensorRosBridgePort(url, hcf.rh, bridge, vs, rmfo, sh)
 
 if __name__ == '__main__':
     print program_name, "start"

--- a/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridgeImpl.cpp
+++ b/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridgeImpl.cpp
@@ -117,16 +117,25 @@ RTC::ReturnCode_t HrpsysSeqStateROSBridgeImpl::onInitialize()
   int nforce  = npforce + nvforce;
   m_rsforce.resize(nforce);
   m_rsforceIn.resize(nforce);
+  m_mcforce.resize(npforce/2+nvforce);
+  m_mcforceIn.resize(npforce/2+nvforce);
   for (unsigned int i=0; i<npforce/2; i++){
     hrp::Sensor *s = body->sensor(hrp::Sensor::FORCE, i);
+    // force and moment
     m_rsforceIn[i*2] = new InPort<TimedDoubleSeq>(s->name.c_str(), m_rsforce[i*2]);
     m_rsforce[i*2].data.length(6);
     registerInPort(s->name.c_str(), *m_rsforceIn[i*2]);
     m_rsforceName.push_back(s->name);
+    // off force and moment
     m_rsforceIn[i*2+1] = new InPort<TimedDoubleSeq>(std::string("off_" + s->name).c_str(), m_rsforce[i*2+1]);
     m_rsforce[i*2+1].data.length(6);
     registerInPort(s->name.c_str(), *m_rsforceIn[i*2+1]);
     m_rsforceName.push_back(std::string("off_" + s->name));
+    // ref force and moment
+    m_mcforceIn[i] = new InPort<TimedDoubleSeq>(std::string("ref_" + s->name).c_str(), m_mcforce[i]);
+    m_mcforce[i].data.length(6);
+    registerInPort(std::string("ref_" + s->name).c_str(), *m_mcforceIn[i]);
+    m_mcforceName.push_back(std::string("ref_" + s->name));
     std::cerr << i << " physical force sensor : " << s->name << std::endl;
   }
 
@@ -165,10 +174,17 @@ RTC::ReturnCode_t HrpsysSeqStateROSBridgeImpl::onInitialize()
     for (int k = 0; k < 7; k++ ) {
         coil::stringTo(tr[k], virtual_force_sensor[j*10+3+k].c_str());
     }
+    // virtual force and moment
     m_rsforceIn[i] = new InPort<TimedDoubleSeq>(name.c_str(), m_rsforce[i]);
     m_rsforce[i].data.length(6);
     registerInPort(name.c_str(), *m_rsforceIn[i]);
     m_rsforceName.push_back(name);
+    // reference virtual force and moment
+    unsigned int j2 = j+npforce/2;
+    m_mcforceIn[j2] = new InPort<TimedDoubleSeq>(std::string("ref_"+name).c_str(), m_mcforce[j2]);
+    m_mcforce[j2].data.length(6);
+    registerInPort(std::string("ref_"+name).c_str(), *m_mcforceIn[j2]);
+    m_mcforceName.push_back(std::string("ref_"+name).c_str());
 
 	if ( ! body->link(base) ) {
 	  std::cerr << "ERROR : unknown link : " << base << std::endl;

--- a/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridgeImpl.h
+++ b/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridgeImpl.h
@@ -109,6 +109,9 @@ class HrpsysSeqStateROSBridgeImpl  : public RTC::DataFlowComponentBase
   std::vector<TimedDoubleSeq> m_rsforce;
   std::vector<InPort<TimedDoubleSeq> *> m_rsforceIn;
   std::vector<std::string> m_rsforceName;
+  std::vector<TimedDoubleSeq> m_mcforce;
+  std::vector<InPort<TimedDoubleSeq> *> m_mcforceIn;
+  std::vector<std::string> m_mcforceName;
   std::vector<TimedAcceleration3D> m_gsensor;
   std::vector<InPort<TimedAcceleration3D> *> m_gsensorIn;
   std::vector<std::string> m_gsensorName;


### PR DESCRIPTION
Publish reference wrench from StateHolder wrench data ports.

Connect StateHolder's wrench ports with HrpsysSeqStateROSBridge's wrench ports.
Check existence of wrench ports because hrpsys-base 315.1.9 does not have wrench ports in Seq and Sh.
