### PR TITLE
Add ROS Bridge setting for standalone version CollisionDetector.

### DIFF
--- a/hrpsys_ros_bridge/launch/collision_detector.launch
+++ b/hrpsys_ros_bridge/launch/collision_detector.launch
@@ -11,6 +11,9 @@
   <arg name="MODEL_FILE" default="/opt/jsk/etc/HIRONX/model/main.wrl" />
   <arg name="CONF_FILE" />
 
+  <!-- ros bridge setting -->
+  <arg name="USE_COLLISIONDETECTOR_ROS_BRIDGE" default="false"/>
+
   <!-- launch collision detector -->
   <node pkg="hrpsys" name="CollisionDetectorComp"
         type="CollisionDetectorComp"
@@ -19,7 +22,7 @@
   <rtconnect from="$(arg SIMULATOR_NAME).rtc:q" to="CollisionDetector0.rtc:qRef" />
   <rtactivate component="CollisionDetector0.rtc" />
   <node name="rtmlaunch_collision_detector" pkg="openrtm_tools" type="rtmlaunch.py"
-        args="$(find hrpsys_ros_bridge)/launch/collision_detector.launch" />
+        args="$(find hrpsys_ros_bridge)/launch/collision_detector.launch USE_COLLISIONDETECTOR_ROS_BRIDGE=$(arg USE_COLLISIONDETECTOR_ROS_BRIDGE)" />
 
   <!-- launch collision result publisher -->
   <node pkg="hrpsys_ros_bridge" name="collision_state" type="collision_state.py"
@@ -27,4 +30,13 @@
         args="$(arg MODEL_FILE) $(arg omniorb_args)" >
     <param name="comp_name" type="string" value="CollisionDetector0" />
   </node>
+
+  <!-- launch collision detector ros bridge -->
+  <group if="$(arg USE_COLLISIONDETECTOR_ROS_BRIDGE)" >
+    <node pkg="hrpsys_ros_bridge" name="CollisionDetectorServiceROSBridge" type="CollisionDetectorServiceROSBridgeComp"
+          args="$(arg openrtm_args)" />
+
+    <rtconnect from="CollisionDetectorServiceROSBridge.rtc:CollisionDetectorService" to="CollisionDetector0.rtc:CollisionDetectorService" subscription_type="new"/>
+    <rtactivate component="CollisionDetectorServiceROSBridge.rtc" />
+  </group>
 </launch>


### PR DESCRIPTION
Add ROS Bridge setting for standalone version CollisionDetector.
Add CollisionDetectorROSBridge and connect to standalone CollisionDetector0.
We can configure CollisionDetector0 from ROS service. 

ROSBridge is deactivated by default, so we can keep backward compatibility.

To use ROSBridge + standalone CollisionDetector0,
1. USE_COLLISIONCHECK=false for hrpsys_ros_bridge.launch because this ROS Bridge is not used.
2. USE_COLLISIONDETECTOR_ROS_BRIDGE=true for collision_detector.launch.
