### PR TITLE
Use segment name of body_info as collision detection frame_id.

### DIFF
--- a/hrpsys_ros_bridge/scripts/collision_state.py
+++ b/hrpsys_ros_bridge/scripts/collision_state.py
@@ -59,7 +59,7 @@ def rtc_init () :
         mdlldr = obj._narrow(ModelLoader_idl._0_OpenHRP__POA.ModelLoader)
         rospy.loginfo("  bodyinfo URL = file://"+modelfile)
         body_info = mdlldr.getBodyInfo("file://"+modelfile)
-        root_link_name = body_info._get_links()[0].name
+        root_link_name = body_info._get_links()[0].segments[0].name
 
         root_link_offset = inverse_matrix(concatenate_matrices(translation_matrix(body_info._get_links()[0].translation),
                                                 rotation_matrix(body_info._get_links()[0].rotation[3],


### PR DESCRIPTION
`collision_state.py` does not work for our robots because frame_id `WAIST` does not exist.
Root-link's frame_id is published as `BODY` because `robot_state_publisher` publishes tf based on link names. 

So, I use segment name of body_info as collision detection frame_id.

However, why does the frame_id `WAIST` work on hironx??
