### PR TITLE
pass :rarm instead of 'rhsensor' or 'rasensor' to :set-forcemoment-offse...

### DIFF
--- a/hrpsys_ros_bridge/euslisp/calib-force-sensor-params.l
+++ b/hrpsys_ros_bridge/euslisp/calib-force-sensor-params.l
@@ -97,7 +97,7 @@
       (when fname
         (mapcar #'(lambda (l)
                     (send* *ri* :set-forcemoment-offset-param
-                           (send (car (send robot (car l) :force-sensors)) :name)
+                           (car l)
                            (cdr l)))
                 ret)
         (format t ";; result file => ~A_[robot name]_[date string] in robot's pc.~%" fname)


### PR DESCRIPTION
...t-param

この部分の``(car l)``は``:rarm``とかを返すので，``(send (car (send robot (car l) :force-sensors)) :name)``は``rasensor``とか``rhsensor``とかになりますが，それが引数として渡される``:set-forcemoment-offset-param``は

https://github.com/start-jsk/rtmros_common/blob/master/hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l#L504

ですので，エラーが出ると思います．

このPRで動くことをstaroとhrp2で確認しました．

```lisp
(forceCalib-for-limbs *staro*
  :fname (format nil "/tmp/~A-force-moment-offset.l" (send robot :name))
  :poses (make-default-ForceCalibPoses *staro*))
```
