### PR TITLE
Sample.pos is not installed via deb package, see https://github.com/fkanehiro/openhrp3/issues/46

### DIFF
--- a/hrpsys_ros_bridge/test/test-samplerobot.py
+++ b/hrpsys_ros_bridge/test/test-samplerobot.py
@@ -79,15 +79,16 @@ class TestSampleRobot(unittest.TestCase):
         load_pattern = rospy.ServiceProxy('/SequencePlayerServiceROSBridge/loadPattern', OpenHRP_SequencePlayerService_loadPattern)
         wait_interpolation = rospy.ServiceProxy('/SequencePlayerServiceROSBridge/waitInterpolation', OpenHRP_SequencePlayerService_waitInterpolation)
         basename = rospkg.RosPack().get_path('openhrp3')+'/share/OpenHRP-3.1/sample/controller/SampleController/etc/Sample'
-        tm = 1.0
-        ret = load_pattern(basename = basename, tm = tm)
-        t1 = rospy.get_time()
-        rospy.logwarn("loadPattern = %r %r"%(basename, tm))
-        ret = wait_interpolation()
-        t2 = rospy.get_time()
-        rospy.logwarn("waitInterpolation %f"%(t2-t1))
-        self.assertAlmostEqual(t2-t1, 11, delta=2)
-        #self.assertNotAlmostEqual(trans[1],0,2)
+        if os.path.exists(basename + ".pos")):
+            tm = 1.0
+            ret = load_pattern(basename = basename, tm = tm)
+            t1 = rospy.get_time()
+            rospy.logwarn("loadPattern = %r %r"%(basename, tm))
+            ret = wait_interpolation()
+            t2 = rospy.get_time()
+            rospy.logwarn("waitInterpolation %f"%(t2-t1))
+            self.assertAlmostEqual(t2-t1, 11, delta=2)
+            #self.assertNotAlmostEqual(trans[1],0,2)
 
     # send joint angles
     def test_joint_angles(self):


### PR DESCRIPTION
`test_load_pattern` fails due to lack of etc folder in openhrp3 deb, this PR check if the `etc/Sample.pos` exists. and if not, just pass the test.

```
[hrpsys_ros_bridge.rosunit-samplerobot/test_load_pattern][FAILURE]--------------
0.001999999999995339 != 11 within 2 delta
  File "/usr/lib/python2.7/unittest/case.py", line 327, in run
    testMethod()
  File "/opt/ros/hydro/share/hrpsys_ros_bridge/test/test-samplerobot.py", line 89, in test_load_pattern
    self.assertAlmostEqual(t2-t1, 11, delta=2)
  File "/usr/lib/python2.7/unittest/case.py", line 559, in assertAlmostEqual
    raise self.failureException(msg)
--------------------------------------------------------------------------------
```
```
[0m[ INFO] [1424331047.825996611, 16.184000000]: [HrpsysSeqStateROSBridge0] @onExecutece 0 is working at 502[Hz][0m
CAUTION!! The robot is moving without checking self collision detection!!! please define collision_pair in configuration file
[0m[ INFO] [1424331047.966944990, 16.324000000]: [HrpsysJointTrajectoryBridge0] @proc joint_trajectory_server->setSucceeded()[0m
[33m[WARN] [WallTime: 1424331047.993021] [16.350000] tf_echo /WAIST_LINK0 /LARM_LINK7 (0.1022425070991342, 0.44845415892492685, 0.2752720185327598) (0.39244231659555523, -0.5435403393187652, -0.4684201813358661, 0.5754437082770391)
[0m[33m[WARN] [WallTime: 1424331047.994140] [16.350000] difference between two /LARM_LINK7 array([-0.10224251, -0.23845416, -0.25927202]) 0.36679135180721278
[0mok
test_load_pattern (__main__.TestSampleRobot) ... [0m[ INFO] [1424331048.218434853, 16.574000000]: SequencePlayerServiceROSBridge::loadPattern()[0m
pattern not found(/opt/ros/hydro/share/openhrp3/share/OpenHRP-3.1/sample/controller/SampleController/etc/Sample)
[33m[WARN] [WallTime: 1424331048.219299] [16.576000] loadPattern = '/opt/ros/hydro/share/openhrp3/share/OpenHRP-3.1/sample/controller/SampleController/etc/Sample' 1.0
[0m[0m[ INFO] [1424331048.229107330, 16.586000000]: SequencePlayerServiceROSBridge::waitInterpolation()[0m
[33m[WARN] [WallTime: 1424331048.230217] [16.586000] waitInterpolation 0.010000
[0mFAIL
test_odom (__main__.TestSampleRobot) ... [INFO] [WallTime: 1424331048.232010] [16.588000] waiting for /odom
[0m[ INFO] [1424331048.826803956, 17.188000000]: [HrpsysSeqStateROSBridge0] @onExecutece 0 is working at 502[Hz][0m
ok
test_odom_tf (__main__.TestSampleRobot) ... [INFO] [WallTime: 1424331049.241874] [17.600000] waiting for /WAIST_LINK0 to /odom
ok
``