### PR TITLE
need to update like jsk-ros-pkg/jsk_roseus

### DIFF
--- a/setup_upstream.sh
+++ b/setup_upstream.sh
@@ -61,6 +61,7 @@ EOF
 
 wstool merge /tmp/rosinstall.$$ -t $WORKSPACE/src
 wstool info -t $WORKSPACE/src
+wstool update --continue-on-error --abort-changed-uris -t $WORKSPACE/src
 
 echo "*** Done"
 

--- a/setup_upstream.sh
+++ b/setup_upstream.sh
@@ -61,7 +61,7 @@ EOF
 
 wstool merge /tmp/rosinstall.$$ -t $WORKSPACE/src
 wstool info -t $WORKSPACE/src
-wstool update --continue-on-error --abort-changed-uris -t $WORKSPACE/src
+wstool update --abort-changed-uris -t $WORKSPACE/src
 
 echo "*** Done"
 


### PR DESCRIPTION
jsk.rosbuildを初めてやったときのみに起こる気がしますが，jsk-ros-pkg/jsk_roseusの方は https://github.com/jsk-ros-pkg/jsk_roseus/blob/master/setup_upstream.sh#L54 で wstool update をしているのに対し，
以下のようにrtmros_commonの方は wstool update せずに終わってしまうようです．



```bash
 Localname           S SCM  Version-Spec UID  (Spec)  URI  (Spec) [http(s)://...]
 ---------           - ---- ------------ -----------  ---------------------------
 hrpsys              x git                            github.com/fkanehiro/hrpsys-base
 openhrp3            x git                            github.com/fkanehiro/openhrp3
 openrtm_aist_python x git                            github.com/tork-a/openrtm_aist_python-release
 openrtm_aist        x git                            github.com/tork-a/openrtm_aist-release
 rtsprofile          x git                            github.com/tork-a/rtsprofile-release
 rtctree             x git                            github.com/tork-a/rtctree-release
 rtshell             x git                            github.com/tork-a/rtshell-release
 jskeus                git               b06bad27c38f github.com/euslisp/jskeus
 euslisp               git               f542489caa65 github.com/euslisp/EusLisp
 geneus                git               5d6d5ff33301 github.com/jsk-ros-pkg/geneus
*** Done

```