### PR TITLE
[setup_upstream.sh] skip document generation for openhrp3

### DIFF
--- a/setup_upstream.sh
+++ b/setup_upstream.sh
@@ -63,6 +63,7 @@ wstool merge /tmp/rosinstall.$$ -t $WORKSPACE/src
 wstool info -t $WORKSPACE/src
 wstool update --abort-changed-uris -t $WORKSPACE/src
 
+sed -i 's@option(ENABLE_DOXYGEN "Use Doxygen" ON)@option(ENABLE_DOXYGEN "Use Doxygen" OFF)@' $WORKSPACE/src/openhrp3/CMakeLists.txt
 sed -i 's@option(ENABLE_DOXYGEN "Use Doxygen" ON)@option(ENABLE_DOXYGEN "Use Doxygen" OFF)@' $WORKSPACE/src/hrpsys/CMakeLists.txt
 
 echo "*** Done"


### PR DESCRIPTION
See comments on #674, I could not find how to disable document generation on openrtm_aist