### PR TITLE
[openrtm_tools] rtmlaunchとrtmtestのaliasを修正

### DIFF
--- a/openrtm_tools/scripts/rtshell-setup.sh
+++ b/openrtm_tools/scripts/rtshell-setup.sh
@@ -18,8 +18,8 @@ if [ -e `rospack find rtshell`/bin ] ; then # if rosbuild
         echo -e "Warning : Failed to load shell_support, try rosmake openrtm_tools"
     fi
 
-    alias rtmlaunch=`rospack find hrpsys_ros_bridge`/scripts/rtmlaunch
-    alias rtmtest=`rospack find hrpsys_ros_bridge`/scripts/rtmtest
+    alias rtmlaunch=`rospack find openrtm_tools`/scripts/rtmlaunch
+    alias rtmtest=`rospack find openrtm_tools`/scripts/rtmtest
 
 else
     IFS=':' read -ra PREFIX_PATH <<< "$CMAKE_PREFIX_PATH"


### PR DESCRIPTION
#677 に伴いopenrtm_tools/scripts/rtshell-setup.shで設定しているrtmlaunchとrtmtestのaliasを修正しました