### PR TITLE
fix minor bug of collision_state.py

### DIFF
--- a/hrpsys_ros_bridge/scripts/collision_state.py
+++ b/hrpsys_ros_bridge/scripts/collision_state.py
@@ -6,6 +6,8 @@ except:
 
 import OpenRTM_aist.RTM_IDL # for catkin
 
+import omniORB
+
 import rospy
 from diagnostic_msgs.msg import *
 
@@ -185,7 +187,7 @@ if __name__ == '__main__':
         while not rospy.is_shutdown():
             try :
                 collision_state()
-            except (CORBA.OBJECT_NOT_EXIST, omniORB.CORBA.TRANSIENT, omniORB.CORBA.BAD_PARAM, omniORB.CORBA.COMM_FAILURE), e :
+            except (omniORB.CORBA.OBJECT_NOT_EXIST, omniORB.CORBA.TRANSIENT, omniORB.CORBA.BAD_PARAM, omniORB.CORBA.COMM_FAILURE), e :
                 rospy.logerr("[collision_state.py] catch exception, restart rtc_init.\nMake sure collision_pair is set in .conf file. See https://github.com/start-jsk/rtmros_common/issues/247\nOriginal exception: {}".format(e))
                 time.sleep(2)
                 rtc_init()


### PR DESCRIPTION
coが登録されているけれど、collision checkがdisableされている場合に、
変更箇所のexceptに入ってこのPRがないとエラーで落ちます。
HRP2実機ではこのプログラムは有効になっておらず（ https://github.com/start-jsk/rtmros_hrp2/blob/master/jsk_hrp2_ros_bridge/launch/jsk_hrp2_ros_bridge.launch#L44 ）、
シミュレータでは常時collision checkがenableであることから、
今まで気づかなかったのだと思います。