### PR TITLE
[hrpsys_ros_bridge] Limits dependent pkg version to avoid critical error in downstream pkgs

### DIFF
--- a/hrpsys_ros_bridge/package.xml
+++ b/hrpsys_ros_bridge/package.xml
@@ -34,7 +34,7 @@
   <build_depend>dynamic_reconfigure</build_depend>
   <build_depend>git</build_depend>
   <build_depend>hostname</build_depend>
-  <build_depend version_gte="315.2.0">hrpsys</build_depend>
+  <build_depend version_gte="315.3.1">hrpsys</build_depend>
   <build_depend>hrpsys_tools</build_depend>
   <build_depend>image_transport</build_depend>
   <build_depend>mk</build_depend>


### PR DESCRIPTION
https://github.com/tork-a/rtmros_nextage/issues/160 requires the suggested version of `hrpsys`.

But I'm not sure if there users who don't need that version.
In that case we might want downstream packages (`hironx_ros_bridge`) that needs to depend on it can add such a dependency.