### PR TITLE
add hours, minutes and seconds for :save-log

### DIFF
--- a/hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l
+++ b/hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l
@@ -237,11 +237,14 @@
   (:get-robot-date-string
    ()
    (let* ((dt (unix:localtime)))
-     (format nil "~A_~A~A~A"
+     (format nil "~A_~A~A~A~A~A~A"
              (send (send self :robot) :name)
              (digits-string (+ 1900 (aref dt 5)) 4)
              (digits-string (1+ (aref dt 4)) 2)
-             (digits-string (aref dt 3) 2))))
+             (digits-string (aref dt 3) 2)
+             (digits-string (aref dt 2) 2)
+             (digits-string (aref dt 1) 2)
+             (digits-string (aref dt 0) 2))))
   )
 
 ;; define Euslisp setter and getter method


### PR DESCRIPTION
dataloggerでlogを取るときに同じ名前で上書いてしまう失敗を良くします．

デフォルトが``ロボット名_年月日``ですが，これに時間と分と秒を追加しても大丈夫でしょうか？