### PR TITLE
[cmake_compile_robot_model.cmake] get_filename_component DIRECTORY is only available > cmake 2.8.12

### DIFF
--- a/hrpsys_ros_bridge/cmake/compile_robot_model.cmake
+++ b/hrpsys_ros_bridge/cmake/compile_robot_model.cmake
@@ -24,7 +24,11 @@ endif()
 ###
 macro(compile_collada_model daefile)
   # dummy set to wrl
-  get_filename_component(_dae_dir_name ${daefile} DIRECTORY)
+  if(${CMAKE_VERSION} VERSION_LESS "2.8.12")
+    get_filename_component(_dae_dir_name ${daefile} PATH)
+  else()
+    get_filename_component(_dae_dir_name ${daefile} DIRECTORY)
+  endif()
   get_filename_component(_dae_file_name ${daefile} NAME_WE)
   compile_openhrp_model(${_dae_dir_name}/${_dae_file_name}.dae)
 endmacro()


### PR DESCRIPTION
this will solve https://github.com/start-jsk/rtmros_gazebo/pull/184#issuecomment-95150708