### PR TITLE
Publish COP for each end effectors

### DIFF
--- a/hrpsys_ros_bridge/launch/hrpsys_ros_bridge.launch
+++ b/hrpsys_ros_bridge/launch/hrpsys_ros_bridge.launch
@@ -135,6 +135,7 @@
     <rtconnect from="AutoBalancerServiceROSBridge.rtc:AutoBalancerService" to="abc.rtc:AutoBalancerService"  subscription_type="new"/>
     <rtconnect from="StabilizerServiceROSBridge.rtc:StabilizerService" to="st.rtc:StabilizerService"  subscription_type="new"/>
     <rtconnect from="KalmanFilterServiceROSBridge.rtc:KalmanFilterService" to="kf.rtc:KalmanFilterService"  subscription_type="new"/>
+    <rtconnect from="st.rtc:COPInfo" to="HrpsysSeqStateROSBridge0.rtc:rsCOPInfo" subscription_type="new"/>
     <rtactivate component="AutoBalancerServiceROSBridge.rtc" />
     <rtactivate component="StabilizerServiceROSBridge.rtc" />
     <rtactivate component="KalmanFilterServiceROSBridge.rtc" />

--- a/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.cpp
+++ b/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.cpp
@@ -761,6 +761,9 @@ RTC::ReturnCode_t HrpsysSeqStateROSBridge::onExecute(RTC::UniqueId ec_id)
       m_rsCOPInfoIn.read();
       //ROS_DEBUG_STREAM("[" << getInstanceName() << "] @onExecute " << m_rsforceName[i] << " size = " << m_rsforce[i].data.length() );
       for (size_t i = 0; i < m_mcforceIn.size(); i++) {
+        std::string tmpname = m_mcforceName[i]; // "ref_xx"
+        tmpname.erase(0,4); // Remove "ref_"
+        if (cop_link_info.find(tmpname) == cop_link_info.end()) continue;
         double fz = m_rsCOPInfo.data[i*3+2];
         if (fz < 1e-3) continue; // If fz is small, do not publish COP.
         geometry_msgs::PointStamped copv;
@@ -769,12 +772,10 @@ RTC::ReturnCode_t HrpsysSeqStateROSBridge::onExecute(RTC::UniqueId ec_id)
         }else{
           copv.header.stamp = tm_on_execute;
         }
-        std::string tmpname = m_mcforceName[i]; // "ref_xx"
-        tmpname.erase(0,4); // Remove "ref_"
-        copv.header.frame_id = tmpname;
+        copv.header.frame_id = cop_link_info[tmpname].link_name;
         copv.point.x = m_rsCOPInfo.data[i*3+1]/fz; // copx = my / fz
         copv.point.y = m_rsCOPInfo.data[i*3]/fz; // copy = mx / fz
-        copv.point.z = 0; // copz is assumed to be equal to ee z position.
+        copv.point.z = cop_link_info[tmpname].cop_offset_z; // cop z position is static.
         cop_pub[i].publish(copv);
       }
     }

--- a/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.h
+++ b/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.h
@@ -54,7 +54,7 @@ class HrpsysSeqStateROSBridge  : public HrpsysSeqStateROSBridgeImpl
   ros::NodeHandle nh;
   ros::Publisher joint_state_pub, joint_controller_state_pub, mot_states_pub, diagnostics_pub, clock_pub, zmp_pub, odom_pub, imu_pub;
   ros::Subscriber trajectory_command_sub;
-  std::vector<ros::Publisher> fsensor_pub;
+  std::vector<ros::Publisher> fsensor_pub, cop_pub;
   actionlib::SimpleActionServer<pr2_controllers_msgs::JointTrajectoryAction> joint_trajectory_server;
   actionlib::SimpleActionServer<control_msgs::FollowJointTrajectoryAction> follow_joint_trajectory_server;
   ros::ServiceServer sendmsg_srv;

--- a/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridgeImpl.cpp
+++ b/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridgeImpl.cpp
@@ -252,6 +252,53 @@ RTC::ReturnCode_t HrpsysSeqStateROSBridgeImpl::onInitialize()
     m_baseRpy.data.y = rpy[2];
   }
 
+  // End effector setting from conf file
+  // rleg,TARGET_LINK,BASE_LINK,x,y,z,rx,ry,rz,rth #<=pos + rot (axis+angle)
+  coil::vstring end_effectors_str = coil::split(prop["end_effectors"], ",");
+  if (end_effectors_str.size() > 0) {
+    size_t prop_num = 10;
+    size_t num = end_effectors_str.size()/prop_num;
+    for (size_t i = 0; i < num; i++) {
+      // Parse end-effector information from conf
+      std::string ee_name, ee_target, ee_base;
+      coil::stringTo(ee_name, end_effectors_str[i*prop_num].c_str());
+      coil::stringTo(ee_target, end_effectors_str[i*prop_num+1].c_str());
+      coil::stringTo(ee_base, end_effectors_str[i*prop_num+2].c_str());
+      hrp::Vector3 eep;
+      for (size_t j = 0; j < 3; j++) {
+        coil::stringTo(eep(j), end_effectors_str[i*prop_num+3+j].c_str());
+      }
+      std::cerr << "[" << m_profile.instance_name << "] End Effector [" << ee_name << "]" << ee_target << " " << ee_base << std::endl;
+      // Find pair between end-effector information and force sensor name
+      bool is_sensor_exists = false;
+      std::string sensor_name;
+      for (size_t ii = 0; ii < m_mcforceName.size(); ii++) {
+        std::string tmpname = m_mcforceName[ii];
+        tmpname.erase(0,4);
+        hrp::ForceSensor* sensor = body->sensor<hrp::ForceSensor>(tmpname);
+        hrp::Link* alink = body->link(ee_target);
+        while (alink != NULL && alink->name != ee_base && !is_sensor_exists) {
+          if ( alink->name == sensor->link->name ) {
+            is_sensor_exists = true;
+            sensor_name = tmpname;
+          }
+          alink = alink->parent;
+        }
+      }
+      if (!is_sensor_exists) {
+        std::cerr << "[" << m_profile.instance_name << "]   No force sensors found [" << ee_target << "]" << std::endl;
+        continue;
+      }
+      // Set cop_link_info
+      COPLinkInfo ci;
+      ci.link_name = sensor_info[sensor_name].link_name; // Link name for tf frame
+      ci.cop_offset_z = eep(2);
+      cop_link_info.insert(std::pair<std::string, COPLinkInfo>(sensor_name, ci));
+      std::cerr << "[" << m_profile.instance_name << "]   target = " << ci.link_name << ", sensor_name = " << sensor_name << std::endl;
+      std::cerr << "[" << m_profile.instance_name << "]   localPos = " << eep.format(Eigen::IOFormat(Eigen::StreamPrecision, 0, ", ", ", ", "", "", "    [", "]")) << "[m]" << std::endl;
+    }
+  }
+
   // </rtc-template>
   return RTC::RTC_OK;
 }

--- a/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridgeImpl.cpp
+++ b/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridgeImpl.cpp
@@ -36,6 +36,7 @@ HrpsysSeqStateROSBridgeImpl::HrpsysSeqStateROSBridgeImpl(RTC::Manager* manager)
     m_rstorqueIn("rstorque", m_rstorque),
     m_servoStateIn("servoState", m_servoState),
     m_rszmpIn("rszmp", m_rszmp),
+    m_rsCOPInfoIn("rsCOPInfo", m_rsCOPInfo),
     m_mctorqueOut("mctorque", m_mctorque),
     m_SequencePlayerServicePort("SequencePlayerService")
 
@@ -60,6 +61,7 @@ RTC::ReturnCode_t HrpsysSeqStateROSBridgeImpl::onInitialize()
   addInPort("rstorque", m_rstorqueIn);
   addInPort("rszmp", m_rszmpIn);
   addInPort("servoState", m_servoStateIn);
+  addInPort("rsCOPInfo", m_rsCOPInfoIn);
 
   // Set OutPort buffer
   addOutPort("mctorque", m_mctorqueOut);

--- a/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridgeImpl.h
+++ b/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridgeImpl.h
@@ -173,6 +173,12 @@ class HrpsysSeqStateROSBridgeImpl  : public RTC::DataFlowComponentBase
   } SensorInfo;
   std::map<std::string, SensorInfo> sensor_info;
 
+  typedef struct  {
+    double cop_offset_z;
+    std::string link_name;
+  } COPLinkInfo;
+  std::map<std::string, COPLinkInfo> cop_link_info;
+
   double dt;
 
  private:

--- a/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridgeImpl.h
+++ b/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridgeImpl.h
@@ -134,6 +134,8 @@ class HrpsysSeqStateROSBridgeImpl  : public RTC::DataFlowComponentBase
   InPort<OpenHRP::TimedLongSeqSeq> m_servoStateIn;
   TimedPoint3D m_rszmp;
   InPort<TimedPoint3D> m_rszmpIn;
+  TimedDoubleSeq m_rsCOPInfo;
+  InPort<TimedDoubleSeq> m_rsCOPInfoIn;
 
   // </rtc-template>
 


### PR DESCRIPTION
DO NOT MERGE YET.

Publish COP for each end effectors.
COPInfo is provided by Stabilizer.

@garaemon,
Currently end-effector TF (= end-coords in euslisp) is not published in ros bridge examples such as `rtmlaunch hrpsys_ros_bridge_tutorials samplerobot.launch`. 
I'd like to use end-effector TF for COP publishing.
Which program publishes end-effector TF?