### PR TITLE
[hrpsys_ros_bridge] Run event loop for 1 sec after showing splashwindow to force to load image immediately

### DIFF
--- a/hrpsys_ros_bridge/src/hrpsys_ros_bridge/hrpsys_dashboard.py
+++ b/hrpsys_ros_bridge/src/hrpsys_ros_bridge/hrpsys_dashboard.py
@@ -39,7 +39,9 @@ class HrpsysSplashScreen():
         self.splash = QSplashScreen(splash_pix, Qt.WindowStaysOnTopHint)
         self.splash.setMask(splash_pix.mask())
         self.splash.show()
-        QApplication.processEvents()
+        for i in range(100):
+            time.sleep(0.01)
+            QApplication.processEvents()
     def kill(self):
         self.splash.close()
 # subclasses required for hrpsys_dasboard


### PR DESCRIPTION
see this discussion to show splash image immediately http://stackoverflow.com/questions/14989749/why-qsplashscreen-does-not-always-work