### PR TITLE
Do not use openhrp3 source for euslisp test job

### DIFF
--- a/setup_upstream.sh
+++ b/setup_upstream.sh
@@ -47,12 +47,15 @@ EOF
     done
 fi
 
-# update HISTORY-{en,ja}.txt, CMakeLists.txt(OPENHRP_VERSION) and ask kanehiro-san for set tag
-cat <<EOF >> /tmp/rosinstall.$$
+if [ "$IS_EUSLISP_TRAVIS_TEST" != "true" ] ; then
+#    wstool remove openhrp3
+    # update HISTORY-{en,ja}.txt, CMakeLists.txt(OPENHRP_VERSION) and ask kanehiro-san for set tag
+    cat <<EOF >> /tmp/rosinstall.$$
 - git:
     uri: http://github.com/fkanehiro/openhrp3
     local-name: openhrp3
 EOF
+fi
 
 # update package.xml, CMakeLists.txt(CMAKE_PACKAGE_VERSION) and ask kanehiro-san for set tag
 cat <<EOF >> /tmp/rosinstall.$$


### PR DESCRIPTION
Do not use openhrp3 source for euslisp test job.
https://github.com/start-jsk/rtmros_common/pull/806#issuecomment-137738243
