### PR TITLE
Fix VRML path for pa10 hrpsys_tools test

### DIFF
--- a/hrpsys_tools/samples/pa10.launch
+++ b/hrpsys_tools/samples/pa10.launch
@@ -2,7 +2,7 @@
   <arg name="GUI" default="true" />
   <arg name="corbaport" default="15005" />
   <include file="$(find hrpsys_tools)/launch/hrpsys.launch" >
-    <arg name="MODEL_FILE" value="$(find openhrp3)/share/OpenHRP-3.1/sample/model/sample1.wrl" />
+    <arg name="MODEL_FILE" value="$(find openhrp3)/share/OpenHRP-3.1/sample/model/PA10/pa10.main.wrl" />
     <arg name="CONF_FILE" value="$(find  hrpsys)/share/hrpsys/samples/PA10/PA10.conf" />
     <arg name="PROJECT_FILE" value="$(find  hrpsys)/share/hrpsys/samples/PA10/PA10simulation.xml" />
     <arg name="SIMULATOR_NAME" value="PA10Controller(Robot)0" />


### PR DESCRIPTION
Fix VRML path for pa10 hrpsys_tools test according to https://github.com/start-jsk/rtmros_common/pull/826#issuecomment-140936622