### PR TITLE
Update 4leg parameter

### DIFF
--- a/hrpsys_ros_bridge/src/hrpsys_ros_bridge/sample4legrobot_hrpsys_config.py
+++ b/hrpsys_ros_bridge/src/hrpsys_ros_bridge/sample4legrobot_hrpsys_config.py
@@ -13,7 +13,7 @@ class Sample4LegRobotHrpsysConfigurator(HrpsysConfigurator):
     def init (self, robotname="Sample4LegRobot", url=""):
         HrpsysConfigurator.init(self, robotname, url)
         print "initialize rtc parameters"
-#        self.setStAbcParameters()
+        self.setStAbcParameters()
 
     def defJointGroups (self):
         rleg_6dof_group = ['rleg', ['RLEG_JOINT0', 'RLEG_JOINT1', 'RLEG_JOINT2', 'RLEG_JOINT3', 'RLEG_JOINT4', 'RLEG_JOINT5']]

--- a/hrpsys_ros_bridge/src/hrpsys_ros_bridge/sample4legrobot_hrpsys_config.py
+++ b/hrpsys_ros_bridge/src/hrpsys_ros_bridge/sample4legrobot_hrpsys_config.py
@@ -28,6 +28,7 @@ class Sample4LegRobotHrpsysConfigurator(HrpsysConfigurator):
         hcf.abc_svc.setAutoBalancerParam(abcp)
         ggp = hcf.abc_svc.getGaitGeneratorParam()[1]
         ggp.zmp_weight_map = [1.0]*4
+        ggp.default_step_height = 0.009 # see https://github.com/fkanehiro/hrpsys-base/issues/801
         hcf.abc_svc.setGaitGeneratorParam(ggp)
         stp_org = hcf.st_svc.getParameter()
         # for tpcc
@@ -39,6 +40,18 @@ class Sample4LegRobotHrpsysConfigurator(HrpsysConfigurator):
         stp_org.eefm_leg_outside_margin=71.12*1e-3
         stp_org.eefm_leg_front_margin=182.0*1e-3
         stp_org.eefm_leg_rear_margin=72.0*1e-3
+        stp_org.st_algorithm=OpenHRP.StabilizerService.EEFMQPCOP
+        rleg_vertices = [OpenHRP.StabilizerService.TwoDimensionVertex(pos=[stp_org.eefm_leg_front_margin, stp_org.eefm_leg_inside_margin]),
+                         OpenHRP.StabilizerService.TwoDimensionVertex(pos=[stp_org.eefm_leg_front_margin, -1*stp_org.eefm_leg_outside_margin]),
+                         OpenHRP.StabilizerService.TwoDimensionVertex(pos=[-1*stp_org.eefm_leg_rear_margin, -1*stp_org.eefm_leg_outside_margin]),
+                         OpenHRP.StabilizerService.TwoDimensionVertex(pos=[-1*stp_org.eefm_leg_rear_margin, stp_org.eefm_leg_inside_margin])]
+        lleg_vertices = [OpenHRP.StabilizerService.TwoDimensionVertex(pos=[stp_org.eefm_leg_front_margin, stp_org.eefm_leg_outside_margin]),
+                         OpenHRP.StabilizerService.TwoDimensionVertex(pos=[stp_org.eefm_leg_front_margin, -1*stp_org.eefm_leg_inside_margin]),
+                         OpenHRP.StabilizerService.TwoDimensionVertex(pos=[-1*stp_org.eefm_leg_rear_margin, -1*stp_org.eefm_leg_inside_margin]),
+                         OpenHRP.StabilizerService.TwoDimensionVertex(pos=[-1*stp_org.eefm_leg_rear_margin, stp_org.eefm_leg_outside_margin])]
+        rarm_vertices = rleg_vertices
+        larm_vertices = lleg_vertices
+        stp_org.eefm_support_polygon_vertices_sequence = map (lambda x : OpenHRP.StabilizerService.SupportPolygonVertices(vertices=x), [lleg_vertices, rleg_vertices, larm_vertices, rarm_vertices])
         stp_org.eefm_k1=[-1.39899,-1.39899]
         stp_org.eefm_k2=[-0.386111,-0.386111]
         stp_org.eefm_k3=[-0.175068,-0.175068]
@@ -47,7 +60,8 @@ class Sample4LegRobotHrpsysConfigurator(HrpsysConfigurator):
         stp_org.is_ik_enable = [True]*4
         stp_org.is_feedback_control_enable = [True]*4
         stp_org.is_zmp_calc_enable = [True]*4
-        stp_org.st_algorithm=OpenHRP.StabilizerService.EEFMQP
+        stp_org.eefm_use_force_difference_control=False
+        stp_org.st_algorithm=OpenHRP.StabilizerService.EEFMQPCOP
         hcf.st_svc.setParameter(stp_org)
 
     def __init__(self, robotname=""):


### PR DESCRIPTION
original PR : https://github.com/start-jsk/rtmros_tutorials/pull/416

#### launch torque-based simulator 

```bash
openhrp-project-generator `rospack find openhrp3`/share/OpenHRP-3.1/sample/model/sample_4leg_robot_bush.wrl `rospack find openhrp3`/share/OpenHRP-3.1/sample/model/longfloor.wrl --use-highgain-mode false --output /tmp/Sample4LegRobot_for_torquecontrol.xml --timeStep 0.001 --dt 0.002 --method RUNGE_KUTTA && export BUSH_CUSTOMIZER_CONFIG_PATH=`rospack find openhrp3`/../OpenHRP-3.1/customizer/sample_4leg_robot_bush_customizer_param.conf && rtmlaunch hrpsys_ros_bridge sample4legrobot.launch PROJECT_FILE:=/tmp/Sample4LegRobot_for_torquecontrol.xml hrpsys_precreate_rtc:=PDcontroller USE_UNSTABLE_RTC:=true RUN_RVIZ:=false
```

#### st + abc trot walking

```lisp
(progn
  (load "package://hrpsys_ros_bridge/euslisp/sample4legrobot-interface.l")
  (setq *robot* (sample4legrobot-init))
  (send *ri* :angle-vector (send *robot* :reset-pose))
  (send *ri* :wait-interpolation)
  (send *ri* :start-auto-balancer :limbs '(:rleg :lleg :rarm :larm))
  (send *ri* :start-st)
  (send *ri* :set-foot-steps
        (list (list (make-coords :coords (send *robot* :lleg :end-coords :copy-worldcoords) :name :lleg)
                    (make-coords :coords (send *robot* :rarm :end-coords :copy-worldcoords) :name :rarm))
              (list (make-coords :coords (send (send *robot* :rleg :end-coords :copy-worldcoords) :translate #f(150 0 0)) :name :rleg)
                    (make-coords :coords (send (send *robot* :larm :end-coords :copy-worldcoords) :translate #f(150 0 0)) :name :larm))
              (list (make-coords :coords (send (send *robot* :lleg :end-coords :copy-worldcoords) :translate #f(300 0 0)) :name :lleg)
                    (make-coords :coords (send (send *robot* :rarm :end-coords :copy-worldcoords) :translate #f(300 0 0)) :name :rarm))
              (list (make-coords :coords (send (send *robot* :rleg :end-coords :copy-worldcoords) :translate #f(450 0 0)) :name :rleg)
                    (make-coords :coords (send (send *robot* :larm :end-coords :copy-worldcoords) :translate #f(450 0 0)) :name :larm))
              (list (make-coords :coords (send (send *robot* :lleg :end-coords :copy-worldcoords) :translate #f(450 0 0)) :name :lleg)
                    (make-coords :coords (send (send *robot* :rarm :end-coords :copy-worldcoords) :translate #f(450 0 0)) :name :rarm))
              ))
  )
```