### PR TITLE
fix conversion to RobotHardware0

### DIFF
--- a/hrpsys_ros_bridge/euslisp/datalogger-log-parser.l
+++ b/hrpsys_ros_bridge/euslisp/datalogger-log-parser.l
@@ -86,7 +86,7 @@
                                    :name (let ((nm (pathname-type x)))
                                            (read-from-string
                                             (if (and (substringp "(" nm) (substringp ")" nm))
-                                                (format nil "RobotHardware0_~A" (cadr (data-string-split nm "_")))
+                                                (format nil "RobotHardware0_~A" (car (last (data-string-split nm "_"))))
                                               nm)))))
                      (append (remove-if-not #'(lambda (x) (substringp "(" x)) fname-candidate-list)
                              fname-candidate-list-with-valid-line-without-rh)))


### PR DESCRIPTION
JAXON_REDのようにロボット名に _ を含むロボットでは，ログファイル名の変換がうまくできていなかったので修正しました．