### PR TITLE
[hrpsys_ros_bridge/test/test-samplerobot.*] add a test program for in…

### DIFF
--- a/hrpsys_ros_bridge/test/test-samplerobot.py
+++ b/hrpsys_ros_bridge/test/test-samplerobot.py
@@ -9,7 +9,7 @@ try:
 except:
     import roslib; roslib.load_manifest(PKG)
 
-import argparse,unittest,rostest, time, sys, math, os
+import argparse,unittest,rostest, time, sys, math, os, rospkg
 from numpy import *
 
 import rospy,rospkg, tf
@@ -120,6 +120,17 @@ class TestSampleRobot(unittest.TestCase):
         rospy.logwarn("tf_echo /WAIST_LINK0 /LARM_LINK7 %r %r"%(trans2,rot2))
         rospy.logwarn("difference between two /LARM_LINK7 %r %r"%(array(trans1)-array(trans2),linalg.norm(array(trans1)-array(trans2))))
         self.assertNotAlmostEqual(linalg.norm(array(trans1)-array(trans2)), 0, delta=0.1)
+
+    def test_hcf_init(self):
+        sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))+"/src/hrpsys_ros_bridge")
+        import samplerobot_hrpsys_config
+        hcf = samplerobot_hrpsys_config.SampleRobotHrpsysConfigurator()
+        model_url = rospkg.RosPack().get_path("openhrp3") + "/share/OpenHRP-3.1/sample/model/sample1.wrl"
+        try:
+            hcf.init("SampleRobot(Robot)0", model_url)
+            assert(True)
+        except AttributeError:
+            assert(False)
 
 #unittest.main()
 if __name__ == '__main__':

--- a/hrpsys_ros_bridge/test/test-samplerobot.test
+++ b/hrpsys_ros_bridge/test/test-samplerobot.test
@@ -6,6 +6,7 @@
     <arg name="corbaport" default="2809" />
     <arg name="GUI" default="false" />
     <arg name="RUN_RVIZ" default="false" />
+    <arg name="USE_UNSTABLE_RTC" default="true" />
   </include>
 
   <!-- check if tf is published -->       
@@ -16,6 +17,6 @@
   <param name="hztest_tf/test_duration" value="5.0" />
   <test test-name="hztest_tf" pkg="rostest" type="hztest" name="hztest_tf" retry="4" />
 
-  <test test-name="samplerobot" pkg="hrpsys_ros_bridge" type="test-samplerobot.py" retry="4" time-limit="300"/>
+  <test test-name="samplerobot" pkg="hrpsys_ros_bridge" type="test-samplerobot.py" retry="4" time-limit="300" args="-ORBInitRef NameService=corbaloc:iiop:localhost:2809/NameService"/>
 
 </launch>


### PR DESCRIPTION
…it of hcf

https://github.com/start-jsk/rtmros_common/pull/849#issuecomment-154614925 でのコメントを反映するためのPRです．

travisのテストプログラムの書く場所がここで合っているかよく分からない（.travis/travis.shの一番最後にやっているcatkin_test_resultsでテストをしているのでしょうか？）のですが，
合っているとしたらこれでテストが失敗するはずということで，とりあえずPRを出してみました．

また，

```python
sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))+"/src/hrpsys_ros_bridge")
import samplerobot_hrpsys_config
```

としたときと

```python
from hrpsys.hrpsys_config import *
import OpenHRP
import hrpsys_ros_bridge.samplerobot_hrpsys_config
```

としたときで，hcf.initしたときの挙動が違う（？）気がしていて，
前者だとちゃんとテストプログラムとして動作するのに対し，後者だとテストが中途半端なところで止まってしまってテストプログラムとして動作してくれない理由がよく分からなかったのですが，
ひとまず前者にしてあります．
