### PR TITLE
[rtmbuild/cmake/rtmbuild.cmake] add a "-Wbuse_quotes" option to omniidl

### DIFF
--- a/rtmbuild/cmake/rtmbuild.cmake
+++ b/rtmbuild/cmake/rtmbuild.cmake
@@ -80,6 +80,7 @@ macro(rtmbuild_init)
 
   execute_process(COMMAND pkg-config openrtm-aist --variable=rtm_idlc     OUTPUT_VARIABLE rtm_idlc     OUTPUT_STRIP_TRAILING_WHITESPACE)
   execute_process(COMMAND pkg-config openrtm-aist --variable=rtm_idlflags OUTPUT_VARIABLE rtm_idlflags OUTPUT_STRIP_TRAILING_WHITESPACE)
+  set(rtm_idlflags "${rtm_idlflags} -Wbuse_quotes") # IDLs in hrpsys-base needs this option because of https://github.com/start-jsk/rtmros_common/issues/861. We can remove this after openrtm-aist.pc is updated.
   execute_process(COMMAND pkg-config openrtm-aist --variable=rtm_idldir   OUTPUT_VARIABLE rtm_idldir   OUTPUT_STRIP_TRAILING_WHITESPACE)
   execute_process(COMMAND pkg-config openrtm-aist --variable=rtm_cxx      OUTPUT_VARIABLE rtm_cxx      OUTPUT_STRIP_TRAILING_WHITESPACE)
   execute_process(COMMAND pkg-config openrtm-aist --variable=rtm_cflags   OUTPUT_VARIABLE rtm_cflags   OUTPUT_STRIP_TRAILING_WHITESPACE)


### PR DESCRIPTION
僕の確認不足で申し訳ないのですが https://github.com/fkanehiro/hrpsys-base/pull/878 以降，hrpsys_ros_bridgeをビルドするには，この変更が必要になっています．

hrpsys-baseでのIDLのコンパイルオプションとhrpsys_ros_brdigeでのIDLのコンパイルオプションが異なっているのが原因です．

hpsys-baseの方だけをビルドして動作確認していたために，hrpsys_ros_bridgeの方がビルドできなくなることに気づけませんでした．すみません．（travisがpassするのもおかしい？）

対策として，IDLのコンパイルオプションがhrpsys-baseとhrpsys_ros_bridgeで同じになるようにopenrtm-aistのフォーラムに以下のようにお願いしたのと，このPRでコンパイルオプションを追加してhrpsys_ros_bridgeがビルドできるようにしました．

http://www.openrtm.org/openrtm/ja/content/omniidl%E3%81%AE%E3%82%AA%E3%83%97%E3%82%B7%E3%83%A7%E3%83%B3%E3%81%AB-wbusequotes%E3%82%92%E8%BF%BD%E5%8A%A0%E3%81%97%E3%81%9F%E3%81%84

関連するissueは以下になります．

- https://github.com/start-jsk/rtmros_common/issues/861
- https://github.com/tork-a/openrtm_aist-release/pull/4


ご確認よろしくお願いします．