### PR TITLE
Use joint_states instead of odom to check tf

### DIFF
--- a/hrpsys_ros_bridge/test/test-samplerobot.test
+++ b/hrpsys_ros_bridge/test/test-samplerobot.test
@@ -9,7 +9,7 @@
   </include>
 
   <!-- check if tf is published -->       
-  <param name="hztest_tf/topic" value="/odom" />
+  <param name="hztest_tf/topic" value="/joint_states" />
   <param name="hztest_tf/wait_time" value="100" />
   <param name="hztest_tf/hz" value="500.0" />
   <param name="hztest_tf/hzerror" value="200.0" />


### PR DESCRIPTION
Use joint_states instead of odom to check tf because joint_states is more related with tf and [Hz] printing than odom.
https://github.com/start-jsk/rtmros_common/issues/877