### PR TITLE
Combine footcoords functions to hrpsys seq state ros bridge

### DIFF
--- a/hrpsys_ros_bridge/catkin.cmake
+++ b/hrpsys_ros_bridge/catkin.cmake
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(hrpsys_ros_bridge)
 
 # call catkin depends
-find_package(catkin REQUIRED COMPONENTS rtmbuild roscpp rostest sensor_msgs robot_state_publisher actionlib control_msgs tf camera_info_manager hrpsys_tools image_transport dynamic_reconfigure nav_msgs geometry_msgs pr2_controllers_msgs pr2_msgs) # robot_monitor
+find_package(catkin REQUIRED COMPONENTS rtmbuild roscpp rostest sensor_msgs robot_state_publisher actionlib control_msgs tf camera_info_manager hrpsys_tools image_transport dynamic_reconfigure nav_msgs geometry_msgs pr2_controllers_msgs pr2_msgs eigen_conversions) # robot_monitor
 find_package(hrpsys QUIET) # on indigo, hrpsys is not ros package
 if(NOT ${hrpsys_FOUND})
   find_package(PkgConfig)

--- a/hrpsys_ros_bridge/catkin.cmake
+++ b/hrpsys_ros_bridge/catkin.cmake
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(hrpsys_ros_bridge)
 
 # call catkin depends
-find_package(catkin REQUIRED COMPONENTS rtmbuild roscpp rostest sensor_msgs robot_state_publisher actionlib control_msgs tf camera_info_manager hrpsys_tools image_transport dynamic_reconfigure nav_msgs geometry_msgs pr2_controllers_msgs pr2_msgs eigen_conversions) # robot_monitor
+find_package(catkin REQUIRED COMPONENTS rtmbuild roscpp rostest sensor_msgs robot_state_publisher actionlib control_msgs tf camera_info_manager hrpsys_tools image_transport dynamic_reconfigure nav_msgs geometry_msgs pr2_controllers_msgs pr2_msgs eigen_conversions tf_conversions) # robot_monitor
 find_package(hrpsys QUIET) # on indigo, hrpsys is not ros package
 if(NOT ${hrpsys_FOUND})
   find_package(PkgConfig)

--- a/hrpsys_ros_bridge/launch/hrpsys_ros_bridge.launch
+++ b/hrpsys_ros_bridge/launch/hrpsys_ros_bridge.launch
@@ -136,6 +136,7 @@
     <rtconnect from="abc.rtc:contactStates" to="HrpsysSeqStateROSBridge0.rtc:refContactStates" subscription_type="new"/>
     <rtconnect from="abc.rtc:controlSwingSupportTime" to="HrpsysSeqStateROSBridge0.rtc:controlSwingSupportTime" subscription_type="new"/>
     <rtconnect from="kf.rtc:rpy" to="HrpsysSeqStateROSBridge0.rtc:baseRpy" subscription_type="new"/>
+    <rtconnect from="kf.rtc:baseRpyCurrent" to="HrpsysSeqStateROSBridge0.rtc:baseRpyCurrent" subscription_type="new"/>
     <rtconnect from="st.rtc:zmp" to="HrpsysSeqStateROSBridge0.rtc:rszmp" subscription_type="new"/>
     <rtconnect from="st.rtc:refCapturePoint" to="HrpsysSeqStateROSBridge0.rtc:rsrefCapturePoint" subscription_type="new"/>
     <rtconnect from="st.rtc:actCapturePoint" to="HrpsysSeqStateROSBridge0.rtc:rsactCapturePoint" subscription_type="new"/>

--- a/hrpsys_ros_bridge/package.xml
+++ b/hrpsys_ros_bridge/package.xml
@@ -62,6 +62,7 @@
   <build_depend>tf</build_depend>
   <build_depend>visualization_msgs</build_depend>
   <build_depend>geometry_msgs</build_depend>
+  <build_depend>eigen_conversions</build_depend>
 
   <run_depend>actionlib</run_depend>
   <run_depend>camera_info_manager</run_depend>
@@ -92,6 +93,7 @@
   <run_depend>tf</run_depend>
   <run_depend>visualization_msgs</run_depend>
   <run_depend>geometry_msgs</run_depend>
+  <build_depend>eigen_conversions</build_depend>  
   <!-- <test_depend>hrpsys</test_depend> -->
   <!-- <test_depend>hrpsys_tools</test_depend> -->
   <!-- <test_depend>openrtm_tools</test_depend> -->

--- a/hrpsys_ros_bridge/package.xml
+++ b/hrpsys_ros_bridge/package.xml
@@ -63,6 +63,7 @@
   <build_depend>visualization_msgs</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>eigen_conversions</build_depend>
+  <build_depend>tf_conversions</build_depend>
 
   <run_depend>actionlib</run_depend>
   <run_depend>camera_info_manager</run_depend>
@@ -93,7 +94,8 @@
   <run_depend>tf</run_depend>
   <run_depend>visualization_msgs</run_depend>
   <run_depend>geometry_msgs</run_depend>
-  <build_depend>eigen_conversions</build_depend>  
+  <run_depend>eigen_conversions</run_depend>
+  <run_depend>tf_conversions</run_depend>  
   <!-- <test_depend>hrpsys</test_depend> -->
   <!-- <test_depend>hrpsys_tools</test_depend> -->
   <!-- <test_depend>openrtm_tools</test_depend> -->

--- a/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.cpp
+++ b/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.cpp
@@ -8,6 +8,7 @@
 #include "rtm/idl/RTC.hh"
 #include "hrpsys_ros_bridge/idl/ExecutionProfileService.hh"
 #include "hrpsys_ros_bridge/idl/RobotHardwareService.hh"
+#include <eigen_conversions/eigen_msg.h>
 #include <boost/format.hpp>
 
 // Module specification
@@ -540,108 +541,18 @@ RTC::ReturnCode_t HrpsysSeqStateROSBridge::onExecute(RTC::UniqueId ec_id)
   if ( m_baseTformIn.isNew () ) {
     m_baseTformIn.read();
     is_base_valid = true;
-    // tf::Transform base;
+    // calculate base transform
     double *a = m_baseTform.data.get_buffer();
-    base.setOrigin( tf::Vector3(a[0], a[1], a[2]) );
+    hrp::Vector3 base_origin = hrp::Vector3(a[0], a[1], a[2]);
+    base.setOrigin(tf::Vector3(base_origin[0], base_origin[1], base_origin[2]));
+    // calculate pose quaternion
     hrp::Matrix33 R;
     hrp::getMatrix33FromRowMajorArray(R, a, 3);
-    
     hrp::Vector3 rpy = hrp::rpyFromRot(R);
-    base.setRotation( tf::createQuaternionFromRPY(rpy(0), rpy(1), rpy(2)));
     tf::Quaternion q = tf::createQuaternionFromRPY(rpy(0), rpy(1), rpy(2));
-    nav_msgs::Odometry odom;
-    //odom.header.frame_id = rootlink_name;
-    odom.header.frame_id = "odom";
-    if ( use_hrpsys_time ) {
-      odom.header.stamp = ros::Time(m_baseTform.tm.sec, m_baseTform.tm.nsec);
-    } else {
-      odom.header.stamp = tm_on_execute;
-    }
-    // odom.child_frame_id = "/odom";
-    odom.child_frame_id = rootlink_name;
-    odom.pose.pose.position.x = a[0];
-    odom.pose.pose.position.y = a[1];
-    odom.pose.pose.position.z = a[2];
-    odom.pose.pose.orientation.x = q.getX();
-    odom.pose.pose.orientation.y = q.getY();
-    odom.pose.pose.orientation.z = q.getZ();
-    odom.pose.pose.orientation.w = q.getW();
+    base.setRotation(q);
     
-    if (prev_odom_acquired) {
-      // calc velocity
-      double dt = (odom.header.stamp - prev_odom.header.stamp).toSec();
-      if (dt > 0) {
-        hrp::Matrix33 prev_R = hrp::rotFromRpy(prev_rpy[0], prev_rpy[1], prev_rpy[2]);
-        // R = exp(omega_w*dt) * prev_R
-        // omega_w is described in global coordinates in relationships of twist transformation.
-        // omega in twist.angular is transformed into rootlink coords because twist should be described in child_frame_id.
-        hrp::Vector3 omega = R.transpose() * hrp::omegaFromRot(R * prev_R.transpose()) / dt;  // omegaFromRot returns matrix_log
-        odom.twist.twist.angular.x = omega[0];
-        odom.twist.twist.angular.y = omega[1];
-        odom.twist.twist.angular.z = omega[2];
-        // calculate velocity (not strict linear twist from odom)
-        hrp::Vector3 velocity, local_velocity;
-        velocity[0] = (odom.pose.pose.position.x - prev_odom.pose.pose.position.x) / dt;
-        velocity[1] = (odom.pose.pose.position.y - prev_odom.pose.pose.position.y) / dt;
-        velocity[2] = (odom.pose.pose.position.z - prev_odom.pose.pose.position.z) / dt;
-        local_velocity = R.transpose() * velocity; // global -> local
-        odom.twist.twist.linear.x = local_velocity[0];
-        odom.twist.twist.linear.y = local_velocity[1];
-        odom.twist.twist.linear.z = local_velocity[2];
-        
-        // calculate covariance
-        // assume dx, dy >> dz, dgamma >> dalpha, dbeta and use 2d odometry update equation
-        Eigen::VectorXd sigma(6);
-        sigma << 1.0, 1.0, 0.001, 0.001, 0.001, 0.1; // velocitis are assumed to have constant standard deviations and they are described in base_link local coordinates
-        if (std::abs(local_velocity[0]) < 0.01) {
-          sigma[0] = 0.001; // trust "stop" state in x
-        }
-        if (std::abs(local_velocity[1]) < 0.01) {
-          sigma[1] = 0.001; // trust "stop" state in y
-        }
-        if (std::abs(omega[2]) < 0.01) {
-          sigma[5] = 0.001; // trust "stop" state in theta
-        }
-        Eigen::Matrix<double,6,6> prev_pose_cov;
-        for(int i = 0; i < 6; i++) { // index in col
-          for (int j = 0; j < 6; j++) { // index in raw
-            prev_pose_cov(i, j) = prev_odom.pose.covariance[6 * i + j];
-          }
-        }
-        // each variance are assumed to be independent        
-        Eigen::VectorXd sigma2(6);
-        for (int i = 0; i < 6; i++) {
-          sigma2[i] = sigma[i] * sigma[i];
-        }
-        Eigen::Matrix<double,6,6> twist_transformation = Eigen::Matrix<double,6,6>::Zero(); // matrix [[R, 0], [0, R]] to convert twist from local to global
-        for (int i = 0; i < 3; i++) {
-          for (int j = 0; j < 3; j++) {
-            twist_transformation(i, j) = R(i, j);
-            twist_transformation(i + 3, j + 3) = R(i, j);
-          }
-        }
-        Eigen::Matrix<double,6,6> twist_cov = sigma2.asDiagonal(); // twist is described as base_link local coordinates
-        // update covariance according to the relationships from definition of variance: V(x) = E[(x-u) * (x-u)^T]
-        // jacovian is described in world coordinates: x(t+dt) = f(x(t), v(t)), x is in world coordinates
-        Eigen::Matrix<double,6,6> jacobi_velocity = Eigen::Matrix<double,6,6>::Identity() * dt;
-        Eigen::Matrix<double,6,6> pose_cov = prev_pose_cov + jacobi_velocity * (twist_transformation.transpose() * twist_cov * twist_transformation) * jacobi_velocity.transpose();
-        // insert covariance
-        for(int i = 0; i < 6; i++) { // index in col
-          for (int j = 0; j < 6; j++) { // index in raw
-            odom.pose.covariance[6 * i + j] = pose_cov(i, j);
-            odom.twist.covariance[6 * i + j] = twist_cov(i, j);
-          }
-        }
-
-        odom_pub.publish(odom);
-        prev_odom = odom;
-        prev_rpy = rpy;
-      }
-    } else {
-      prev_odom = odom;
-      prev_rpy = rpy;
-      prev_odom_acquired = true;
-    }
+    updateOdometry(base_origin, R, tm_on_execute);
   }  // end: m_baseTformIn
 
   bool updateImu = false;
@@ -977,6 +888,121 @@ RTC::ReturnCode_t HrpsysSeqStateROSBridge::onExecute(RTC::UniqueId ec_id)
 
   //
   return RTC::RTC_OK;
+}
+
+void HrpsysSeqStateROSBridge::updateOdometry(hrp::Vector3 &trans, hrp::Matrix33 &R, ros::Time &stamp)
+{
+  hrp::Vector3 rpy = hrp::rpyFromRot(R);
+  tf::Quaternion q = tf::createQuaternionFromRPY(rpy(0), rpy(1), rpy(2));
+  nav_msgs::Odometry odom;
+  
+  odom.header.frame_id = "odom";
+  if ( use_hrpsys_time ) {
+    odom.header.stamp = ros::Time(m_baseTform.tm.sec, m_baseTform.tm.nsec);
+  } else {
+    odom.header.stamp = stamp;
+  }
+  // odom.child_frame_id = "/odom";
+  odom.child_frame_id = rootlink_name;
+  odom.pose.pose.position.x = trans[0];
+  odom.pose.pose.position.y = trans[1];
+  odom.pose.pose.position.z = trans[2];
+  odom.pose.pose.orientation.x = q.getX();
+  odom.pose.pose.orientation.y = q.getY();
+  odom.pose.pose.orientation.z = q.getZ();
+  odom.pose.pose.orientation.w = q.getW();
+    
+  if (prev_odom_acquired) {
+    // calc velocity
+    double dt = (odom.header.stamp - prev_odom.header.stamp).toSec();
+    if (dt > 0) {
+      hrp::Matrix33 prev_R = hrp::rotFromRpy(prev_rpy[0], prev_rpy[1], prev_rpy[2]);
+      // R = exp(omega_w*dt) * prev_R
+      // omega_w is described in global coordinates in relationships of twist transformation.
+      // omega in twist.angular is transformed into rootlink coords because twist should be described in child_frame_id.
+      hrp::Vector3 omega = R.transpose() * hrp::omegaFromRot(R * prev_R.transpose()) / dt;  // omegaFromRot returns matrix_log
+      odom.twist.twist.angular.x = omega[0];
+      odom.twist.twist.angular.y = omega[1];
+      odom.twist.twist.angular.z = omega[2];
+      // calculate velocity (not strict linear twist from odom)
+      hrp::Vector3 velocity, local_velocity;
+      velocity[0] = (odom.pose.pose.position.x - prev_odom.pose.pose.position.x) / dt;
+      velocity[1] = (odom.pose.pose.position.y - prev_odom.pose.pose.position.y) / dt;
+      velocity[2] = (odom.pose.pose.position.z - prev_odom.pose.pose.position.z) / dt;
+      local_velocity = R.transpose() * velocity; // global -> local
+      odom.twist.twist.linear.x = local_velocity[0];
+      odom.twist.twist.linear.y = local_velocity[1];
+      odom.twist.twist.linear.z = local_velocity[2];
+        
+      // calculate covariance
+      // assume dx, dy >> dz, dgamma >> dalpha, dbeta and use 2d odometry update equation
+      Eigen::VectorXd sigma(6);
+      sigma << 1.0, 1.0, 0.001, 0.001, 0.001, 0.1; // velocitis are assumed to have constant standard deviations and they are described in base_link local coordinates
+      if (std::abs(local_velocity[0]) < 0.01) {
+        sigma[0] = 0.001; // trust "stop" state in x
+      }
+      if (std::abs(local_velocity[1]) < 0.01) {
+        sigma[1] = 0.001; // trust "stop" state in y
+      }
+      if (std::abs(omega[2]) < 0.01) {
+        sigma[5] = 0.001; // trust "stop" state in theta
+      }
+      Eigen::Matrix<double,6,6> prev_pose_cov;
+      for(int i = 0; i < 6; i++) { // index in col
+        for (int j = 0; j < 6; j++) { // index in raw
+          prev_pose_cov(i, j) = prev_odom.pose.covariance[6 * i + j];
+        }
+      }
+      // each variance are assumed to be independent        
+      Eigen::VectorXd sigma2(6);
+      for (int i = 0; i < 6; i++) {
+        sigma2[i] = sigma[i] * sigma[i];
+      }
+      Eigen::Matrix<double,6,6> twist_transformation = Eigen::Matrix<double,6,6>::Zero(); // matrix [[R, 0], [0, R]] to convert twist from local to global
+      for (int i = 0; i < 3; i++) {
+        for (int j = 0; j < 3; j++) {
+          twist_transformation(i, j) = R(i, j);
+          twist_transformation(i + 3, j + 3) = R(i, j);
+        }
+      }
+      Eigen::Matrix<double,6,6> twist_cov = sigma2.asDiagonal(); // twist is described as base_link local coordinates
+      // update covariance according to the relationships from definition of variance: V(x) = E[(x-u) * (x-u)^T]
+      // jacovian is described in world coordinates: x(t+dt) = f(x(t), v(t)), x is in world coordinates
+      Eigen::Matrix<double,6,6> jacobi_velocity = Eigen::Matrix<double,6,6>::Identity() * dt;
+      Eigen::Matrix<double,6,6> pose_cov = prev_pose_cov + jacobi_velocity * (twist_transformation.transpose() * twist_cov * twist_transformation) * jacobi_velocity.transpose();
+      // insert covariance
+      for(int i = 0; i < 6; i++) { // index in col
+        for (int j = 0; j < 6; j++) { // index in raw
+          odom.pose.covariance[6 * i + j] = pose_cov(i, j);
+          odom.twist.covariance[6 * i + j] = twist_cov(i, j);
+        }
+      }
+      // publish odometry
+      odom_pub.publish(odom);
+
+      // preserve old values
+      prev_odom = odom;
+      prev_rpy = rpy;
+
+      // make affine3d matrix from pose message in odom
+      tf::poseMsgToEigen(odom.pose.pose, odom_pose_matrix);
+
+      // publish transformations
+      std::vector<geometry_msgs::TransformStamped> tf_transforms;
+      geometry_msgs::TransformStamped ros_odom_to_body_coords;
+      ros_odom_to_body_coords.header.stamp = odom.header.stamp;
+      ros_odom_to_body_coords.header.frame_id = "/odom";
+      ros_odom_to_body_coords.child_frame_id = rootlink_name;
+      tf::transformEigenToMsg(odom_pose_matrix, ros_odom_to_body_coords.transform);
+      tf_transforms.push_back(ros_odom_to_body_coords);
+      br.sendTransform(tf_transforms);
+    }
+  } else {
+    // previous values are needed to calculate velocity
+    prev_odom = odom;
+    prev_rpy = rpy;
+    prev_odom_acquired = true;
+  }
 }
 
 extern "C"

--- a/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.cpp
+++ b/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.cpp
@@ -1141,21 +1141,21 @@ void HrpsysSeqStateROSBridge::updateImu(tf::Transform &base, bool is_base_valid,
     Eigen::Affine3d gyrometer_matrix = gyrometer_parent_matrix * (Eigen::Translation3d(gyrometer->localPos) * gyrometer->localR); // odom->gyrometer_link->gyrometer
     tf::Transform gyrometer_transform;
     tf::transformEigenToTF(gyrometer_matrix, gyrometer_transform);
-    tf::Transform root_relative_gyrometer_transform = base.inverse() * gyrometer_transform; // base->odom->gyrometer
+    tf::Transform gyrometer_to_root_transform = gyrometer_transform.inverse() * base; // gyrometer->odom->base
     // orientation
     tf::Transform imu_transform = tf::Transform(q, tf::Vector3(0, 0, 0));
-    tf::Quaternion root_relative_imu_orientation = (root_relative_gyrometer_transform * imu_transform).getRotation();
+    tf::Quaternion root_relative_imu_orientation = (gyrometer_to_root_transform * imu_transform).getRotation();
     tf::quaternionTFToMsg(root_relative_imu_orientation, imu_rootlink.orientation);
     tf::Matrix3x3 orientation_cov_matrix = tf::Matrix3x3(imu.orientation_covariance[0], imu.orientation_covariance[1], imu.orientation_covariance[2],
                                                          imu.orientation_covariance[3], imu.orientation_covariance[4], imu.orientation_covariance[5],
                                                          imu.orientation_covariance[6], imu.orientation_covariance[7], imu.orientation_covariance[8]);
-    tf::Matrix3x3 root_relative_orientation_cov_matrix = root_relative_gyrometer_transform.getBasis().transpose() * orientation_cov_matrix * root_relative_gyrometer_transform.getBasis();
+    tf::Matrix3x3 root_relative_orientation_cov_matrix = gyrometer_to_root_transform.getBasis().transpose() * orientation_cov_matrix * gyrometer_to_root_transform.getBasis();
     for (int i = 0; i < 3; i++) {
       for (int j = 0; j < 3; j++) {
         imu_rootlink.orientation_covariance[3 * i + j] = orientation_cov_matrix[i][j];
       }
     }
-    tf::Vector3 root_relative_imu_angular_velocity = root_relative_gyrometer_transform.getBasis() * tf::Vector3(m_gyrometer[0].data.avx, m_gyrometer[0].data.avy, m_gyrometer[0].data.avz);
+    tf::Vector3 root_relative_imu_angular_velocity = gyrometer_to_root_transform.getBasis() * tf::Vector3(m_gyrometer[0].data.avx, m_gyrometer[0].data.avy, m_gyrometer[0].data.avz);
     tf::vector3TFToMsg(root_relative_imu_angular_velocity, imu_rootlink.angular_velocity);
     imu_rootlink.angular_velocity_covariance = imu.angular_velocity_covariance;
   }
@@ -1165,8 +1165,8 @@ void HrpsysSeqStateROSBridge::updateImu(tf::Transform &base, bool is_base_valid,
     Eigen::Affine3d acceleration_matrix = acceleration_parent_matrix * (Eigen::Translation3d(acceleration->localPos) * acceleration->localR); // odom->acceleration_link->acceleration
     tf::Transform acceleration_transform;
     tf::transformEigenToTF(acceleration_matrix, acceleration_transform);
-    tf::Transform root_relative_acceleration_transform = base.inverse() * acceleration_transform; // base->odom->gyrometer
-    tf::Vector3 root_relative_imu_acceleration = root_relative_acceleration_transform.getBasis() * tf::Vector3(m_gsensor[0].data.ax, m_gsensor[0].data.ay, m_gsensor[0].data.az);
+    tf::Transform acceleration_to_root_transform = acceleration_transform.inverse() * base; // acceleration->odom->base
+    tf::Vector3 root_relative_imu_acceleration = acceleration_to_root_transform.getBasis() * tf::Vector3(m_gsensor[0].data.ax, m_gsensor[0].data.ay, m_gsensor[0].data.az);
     tf::vector3TFToMsg(root_relative_imu_acceleration, imu_rootlink.linear_acceleration);
     imu_rootlink.linear_acceleration_covariance = imu.linear_acceleration_covariance;
   }

--- a/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.cpp
+++ b/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.cpp
@@ -1038,9 +1038,9 @@ void HrpsysSeqStateROSBridge::updateOdomInit(Eigen::Affine3d &odom_pose_matrix, 
     // ignore z height and roll/pitch angle transform from odom assuming odom_init is on the flat ground
     double odom_init_yaw = atan2(odom_pose_matrix(1,0), odom_pose_matrix(0,0)); // ref: pcl::getEulerAngles
     odom_init_transform_matrix = (Eigen::Translation3d(odom_pose_matrix.translation()[0],
-                                                            odom_pose_matrix.translation()[1],
-                                                            0.0) *
-                                       Eigen::AngleAxisd(odom_init_yaw, Eigen::Vector3d::UnitZ()));
+                                                       odom_pose_matrix.translation()[1],
+                                                       0.0) *
+                                  Eigen::AngleAxisd(odom_init_yaw, Eigen::Vector3d::UnitZ()));
     // transform (not be affected by invert_odom_init_tf)
     ros_odom_init_coords.header.stamp = stamp;
     ros_odom_init_coords.header.frame_id = "/odom";
@@ -1073,14 +1073,14 @@ void HrpsysSeqStateROSBridge::publishOdometryTransforms(Eigen::Affine3d &odom_po
     if (invert_odom_init_tf) {
       ros_odom_init_coords.header.frame_id ="/odom_init";
       ros_odom_init_coords.child_frame_id =  "/odom";
-      tf::transformEigenToMsg(odom_init_transform_matrix.inverse(), ros_odom_init_coords.transform); // odom_init_transform_matrix is preserved as a instance valiable
+      tf::transformEigenToMsg(odom_init_transform_matrix.inverse(), ros_odom_init_coords.transform);
     } else {
       ros_odom_init_coords.header.frame_id = "/odom";
       ros_odom_init_coords.child_frame_id = "/odom_init";
-      tf::transformEigenToMsg(odom_init_transform_matrix, ros_odom_init_coords.transform); // odom_init_transform_matrix is preserved as a instance valiable
+      tf::transformEigenToMsg(odom_init_transform_matrix, ros_odom_init_coords.transform);
     }
+    tf_transforms.push_back(ros_odom_init_coords);
   }
-  tf_transforms.push_back(ros_odom_init_coords);
   br.sendTransform(tf_transforms);
 }
 

--- a/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.cpp
+++ b/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.cpp
@@ -1017,9 +1017,8 @@ void HrpsysSeqStateROSBridge::updateGroundTransform(const tf::Transform &odom_po
   std::vector<std::string> leg_names;
   if (isLeggedRobot()) {
     // joint angles are assumed to be already updated
-    hrp::Vector3 body_p;
     tf::vectorTFToEigen(odom_pose_transform.getOrigin(), body->rootLink()->p);
-    tf::matrixTFToEigen(tf::Matrix3x3(odom_pose_transform.getRotation()), body->rootLink()->R);
+    tf::matrixTFToEigen(odom_pose_transform.getBasis(), body->rootLink()->R);
     body->calcForwardKinematics();
     // TODO: do not hard-code leg link name
     leg_names.push_back("lleg"); 

--- a/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.h
+++ b/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.h
@@ -96,7 +96,7 @@ class HrpsysSeqStateROSBridge  : public HrpsysSeqStateROSBridgeImpl
   bool prev_lfoot_contact_state;
   bool prev_rfoot_contact_state;
   bool is_robot_on_ground;
-  bool publish_odom_init_transform, invert_odom_init_tf;
+  bool publish_odom_init_transform, invert_odom_init_tf, check_robot_is_on_ground;
 };
 
 

--- a/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.h
+++ b/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.h
@@ -95,6 +95,7 @@ class HrpsysSeqStateROSBridge  : public HrpsysSeqStateROSBridgeImpl
   bool update_odom_init_flag;
   bool prev_lfoot_contact_state;
   bool prev_rfoot_contact_state;
+  bool publish_odom_init_transform, invert_odom_init_tf;
 };
 
 

--- a/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.h
+++ b/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.h
@@ -56,7 +56,7 @@ class HrpsysSeqStateROSBridge  : public HrpsysSeqStateROSBridgeImpl
  private:
   ros::NodeHandle nh;
   ros::Publisher joint_state_pub, joint_controller_state_pub, mot_states_pub, diagnostics_pub, clock_pub, zmp_pub, ref_cp_pub, act_cp_pub, odom_pub, imu_pub,
-    em_mode_pub, ref_contact_states_pub, act_contact_states_pub, odom_init_pose_stamped_pub, odom_init_transform_pub;
+    em_mode_pub, ref_contact_states_pub, act_contact_states_pub, odom_init_pose_stamped_pub, odom_init_transform_pub, imu_rootlink_pub;
   ros::Subscriber trajectory_command_sub, odom_init_trigger_sub;
   std::vector<ros::Publisher> fsensor_pub, cop_pub;
   actionlib::SimpleActionServer<pr2_controllers_msgs::JointTrajectoryAction> joint_trajectory_server;
@@ -93,6 +93,7 @@ class HrpsysSeqStateROSBridge  : public HrpsysSeqStateROSBridgeImpl
   void odomInitTriggerCB(const std_msgs::Empty &trigger);
   bool isLeggedRobot();
   void updateGroundTransform(Eigen::Affine3d &odom_pose_matrix);
+  void updateImu(tf::Transform &base, bool is_base_valid, ros::Time &stamp);
   boost::mutex odom_init_mutex;
   Eigen::Affine3d odom_init_transform_matrix, ground_transform_matrix;
   bool update_odom_init_flag;

--- a/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.h
+++ b/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.h
@@ -85,13 +85,16 @@ class HrpsysSeqStateROSBridge  : public HrpsysSeqStateROSBridgeImpl
 
   bool follow_action_initialized;
 
+  // odometry relatives
   void updateOdometry(hrp::Vector3 &trans, hrp::Matrix33 &R, ros::Time &stamp);
   bool checkFootContactState(bool lfoot_contact_state, bool rfoot_contact_state);
   void updateOdomInit(Eigen::Affine3d &odom_pose_matrix, ros::Time &stamp);
   void publishOdometryTransforms(Eigen::Affine3d &odom_pose_matrix, ros::Time &stamp);
   void odomInitTriggerCB(const std_msgs::Empty &trigger);
+  bool isLeggedRobot();
+  void updateGroundTransform(Eigen::Affine3d &odom_pose_matrix);
   boost::mutex odom_init_mutex;
-  Eigen::Affine3d odom_init_transform_matrix;
+  Eigen::Affine3d odom_init_transform_matrix, ground_transform_matrix;
   bool update_odom_init_flag;
   bool prev_lfoot_contact_state;
   bool prev_rfoot_contact_state;

--- a/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.h
+++ b/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.h
@@ -16,6 +16,7 @@
 #include "ros/ros.h"
 #include "rosgraph_msgs/Clock.h"
 #include "std_msgs/Int32.h"
+#include "std_msgs/Empty.h"
 #include "sensor_msgs/JointState.h"
 #include "nav_msgs/Odometry.h"
 #include "geometry_msgs/WrenchStamped.h"
@@ -54,8 +55,9 @@ class HrpsysSeqStateROSBridge  : public HrpsysSeqStateROSBridgeImpl
                                hrpsys_ros_bridge::SetSensorTransformation::Response& res);
  private:
   ros::NodeHandle nh;
-  ros::Publisher joint_state_pub, joint_controller_state_pub, mot_states_pub, diagnostics_pub, clock_pub, zmp_pub, ref_cp_pub, act_cp_pub, odom_pub, imu_pub, em_mode_pub, ref_contact_states_pub, act_contact_states_pub;
-  ros::Subscriber trajectory_command_sub;
+  ros::Publisher joint_state_pub, joint_controller_state_pub, mot_states_pub, diagnostics_pub, clock_pub, zmp_pub, ref_cp_pub, act_cp_pub, odom_pub, imu_pub,
+    em_mode_pub, ref_contact_states_pub, act_contact_states_pub, odom_init_pose_stamped_pub, odom_init_transform_pub;
+  ros::Subscriber trajectory_command_sub, odom_init_trigger_sub;
   std::vector<ros::Publisher> fsensor_pub, cop_pub;
   actionlib::SimpleActionServer<pr2_controllers_msgs::JointTrajectoryAction> joint_trajectory_server;
   actionlib::SimpleActionServer<control_msgs::FollowJointTrajectoryAction> follow_joint_trajectory_server;
@@ -84,7 +86,15 @@ class HrpsysSeqStateROSBridge  : public HrpsysSeqStateROSBridgeImpl
   bool follow_action_initialized;
 
   void updateOdometry(hrp::Vector3 &trans, hrp::Matrix33 &R, ros::Time &stamp);
-  Eigen::Affine3d odom_pose_matrix;
+  bool checkFootContactState(bool lfoot_contact_state, bool rfoot_contact_state);
+  void updateOdomInit(Eigen::Affine3d &odom_pose_matrix, ros::Time &stamp);
+  void publishOdometryTransforms(Eigen::Affine3d &odom_pose_matrix, ros::Time &stamp);
+  void odomInitTriggerCB(const std_msgs::Empty &trigger);
+  boost::mutex odom_init_mutex;
+  Eigen::Affine3d odom_init_pose_matrix;
+  bool update_odom_init_flag;
+  bool prev_lfoot_contact_state;
+  bool prev_rfoot_contact_state;
 };
 
 

--- a/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.h
+++ b/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.h
@@ -86,7 +86,7 @@ class HrpsysSeqStateROSBridge  : public HrpsysSeqStateROSBridgeImpl
   bool follow_action_initialized;
 
   // odometry relatives
-  void updateOdometry(hrp::Vector3 &trans, hrp::Matrix33 &R, ros::Time &stamp);
+  void updateOdometry(tf::Transform &base, ros::Time &stamp);
   bool checkFootContactState(bool lfoot_contact_state, bool rfoot_contact_state);
   void updateOdomInit(Eigen::Affine3d &odom_pose_matrix, ros::Time &stamp);
   void publishOdometryTransforms(Eigen::Affine3d &odom_pose_matrix, ros::Time &stamp);
@@ -99,7 +99,7 @@ class HrpsysSeqStateROSBridge  : public HrpsysSeqStateROSBridgeImpl
   bool prev_lfoot_contact_state;
   bool prev_rfoot_contact_state;
   bool is_robot_on_ground;
-  bool publish_odom_init_transform, invert_odom_init_tf, check_robot_is_on_ground;
+  bool publish_odom_init_transform, invert_odom_init_tf, check_robot_is_on_ground, publish_ground_transform;
 };
 
 

--- a/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.h
+++ b/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.h
@@ -86,16 +86,16 @@ class HrpsysSeqStateROSBridge  : public HrpsysSeqStateROSBridgeImpl
   bool follow_action_initialized;
 
   // odometry relatives
-  void updateOdometry(tf::Transform &base, ros::Time &stamp);
+  void updateOdometry(const tf::Transform &base, const ros::Time &stamp);
   bool checkFootContactState(bool lfoot_contact_state, bool rfoot_contact_state);
-  void updateOdomInit(Eigen::Affine3d &odom_pose_matrix, ros::Time &stamp);
-  void publishOdometryTransforms(Eigen::Affine3d &odom_pose_matrix, ros::Time &stamp);
+  void updateOdomInit(const tf::Transform &odom_pose_transform, const ros::Time &stamp);
+  void publishOdometryTransforms(const tf::Transform &odom_pose_transform, const ros::Time &stamp);
   void odomInitTriggerCB(const std_msgs::Empty &trigger);
   bool isLeggedRobot();
-  void updateGroundTransform(Eigen::Affine3d &odom_pose_matrix);
-  void updateImu(tf::Transform &base, bool is_base_valid, ros::Time &stamp);
+  void updateGroundTransform(const tf::Transform &odom_pose_transform);
+  void updateImu(tf::Transform &base, bool is_base_valid, const ros::Time &stamp);
   boost::mutex odom_init_mutex;
-  Eigen::Affine3d odom_init_transform_matrix, ground_transform_matrix;
+  tf::Transform odom_init_transform, ground_transform;
   bool update_odom_init_flag;
   bool prev_lfoot_contact_state;
   bool prev_rfoot_contact_state;

--- a/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.h
+++ b/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.h
@@ -95,6 +95,7 @@ class HrpsysSeqStateROSBridge  : public HrpsysSeqStateROSBridgeImpl
   bool update_odom_init_flag;
   bool prev_lfoot_contact_state;
   bool prev_rfoot_contact_state;
+  bool is_robot_on_ground;
   bool publish_odom_init_transform, invert_odom_init_tf;
 };
 

--- a/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.h
+++ b/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.h
@@ -82,6 +82,9 @@ class HrpsysSeqStateROSBridge  : public HrpsysSeqStateROSBridgeImpl
   void clock_cb(const rosgraph_msgs::ClockPtr& str) {};
 
   bool follow_action_initialized;
+
+  void updateOdometry(hrp::Vector3 &trans, hrp::Matrix33 &R, ros::Time &stamp);
+  Eigen::Affine3d odom_pose_matrix;
 };
 
 

--- a/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.h
+++ b/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.h
@@ -91,7 +91,7 @@ class HrpsysSeqStateROSBridge  : public HrpsysSeqStateROSBridgeImpl
   void publishOdometryTransforms(Eigen::Affine3d &odom_pose_matrix, ros::Time &stamp);
   void odomInitTriggerCB(const std_msgs::Empty &trigger);
   boost::mutex odom_init_mutex;
-  Eigen::Affine3d odom_init_pose_matrix;
+  Eigen::Affine3d odom_init_transform_matrix;
   bool update_odom_init_flag;
   bool prev_lfoot_contact_state;
   bool prev_rfoot_contact_state;

--- a/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridgeImpl.cpp
+++ b/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridgeImpl.cpp
@@ -34,7 +34,7 @@ HrpsysSeqStateROSBridgeImpl::HrpsysSeqStateROSBridgeImpl(RTC::Manager* manager)
     m_mcangleIn("mcangle", m_mcangle),
     m_baseTformIn("baseTform", m_baseTform),
     m_baseRpyIn("baseRpy", m_baseRpy),
-    m_baseRpyCurrentIn("baseRpyCurrentIn", m_baseRpyCurrent),
+    m_baseRpyCurrentIn("baseRpyCurrent", m_baseRpyCurrent),
     m_rsvelIn("rsvel", m_rsvel),
     m_rstorqueIn("rstorque", m_rstorque),
     m_servoStateIn("servoState", m_servoState),

--- a/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridgeImpl.cpp
+++ b/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridgeImpl.cpp
@@ -5,6 +5,7 @@
  * $Id$ 
  */
 #include "HrpsysSeqStateROSBridgeImpl.h"
+#include <tf_conversions/tf_eigen.h>
 
 // Module specification
 // <rtc-template block="module_spec">
@@ -278,20 +279,38 @@ RTC::ReturnCode_t HrpsysSeqStateROSBridgeImpl::onInitialize()
   // End effector setting from conf file
   // rleg,TARGET_LINK,BASE_LINK,x,y,z,rx,ry,rz,rth #<=pos + rot (axis+angle)
   coil::vstring end_effectors_str = coil::split(prop["end_effectors"], ",");
+  std::cerr << " end effector size : " << end_effectors_str.size() << std::endl;
   if (end_effectors_str.size() > 0) {
     size_t prop_num = 10;
     size_t num = end_effectors_str.size()/prop_num;
     for (size_t i = 0; i < num; i++) {
       // Parse end-effector information from conf
       std::string ee_name, ee_target, ee_base;
+      tf::Transform ee_transform;
+      EndEffectorInfo tmp_ee_info;
       coil::stringTo(ee_name, end_effectors_str[i*prop_num].c_str());
       coil::stringTo(ee_target, end_effectors_str[i*prop_num+1].c_str());
       coil::stringTo(ee_base, end_effectors_str[i*prop_num+2].c_str());
+      // make end-effector-info
       hrp::Vector3 eep;
       for (size_t j = 0; j < 3; j++) {
         coil::stringTo(eep(j), end_effectors_str[i*prop_num+3+j].c_str());
       }
+      double eerot[4]; // rotation in VRML is represented by axis + angle
+      for (int j = 0; j < 4; j++ ) {
+        coil::stringTo(eerot[j], end_effectors_str[i*prop_num+6+j].c_str());
+      }
+      Eigen::Affine3d ee_transform_matrix = (Eigen::Translation3d(eep(0), eep(1), eep(2)) *
+                                             Eigen::AngleAxisd(eerot[3], hrp::Vector3(eerot[0], eerot[1], eerot[2])));
+      tmp_ee_info.name = ee_name;
+      tmp_ee_info.target = ee_target;
+      tmp_ee_info.base = ee_base;
+      tf::transformEigenToTF(ee_transform_matrix, tmp_ee_info.transform);
+      ee_info.insert(std::pair<std::string, EndEffectorInfo>(ee_name , tmp_ee_info));
       std::cerr << "[" << m_profile.instance_name << "] End Effector [" << ee_name << "]" << ee_target << " " << ee_base << std::endl;
+      std::cerr << "[" << m_profile.instance_name << "]   translation = " << tmp_ee_info.transform.getOrigin().x() << ", " << tmp_ee_info.transform.getOrigin().y() << ", " << tmp_ee_info.transform.getOrigin().z() << std::endl;
+      std::cerr << "[" << m_profile.instance_name << "]   rotation = " <<  tmp_ee_info.transform.getRotation().getAxis().x() << ", " << tmp_ee_info.transform.getRotation().getAxis().y() << ", "
+                << tmp_ee_info.transform.getRotation().getAxis().z() << ", " << tmp_ee_info.transform.getRotation().getAngle() << std::endl;
       // Find pair between end-effector information and force sensor name
       bool is_sensor_exists = false;
       std::string sensor_name;

--- a/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridgeImpl.cpp
+++ b/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridgeImpl.cpp
@@ -34,6 +34,7 @@ HrpsysSeqStateROSBridgeImpl::HrpsysSeqStateROSBridgeImpl(RTC::Manager* manager)
     m_mcangleIn("mcangle", m_mcangle),
     m_baseTformIn("baseTform", m_baseTform),
     m_baseRpyIn("baseRpy", m_baseRpy),
+    m_baseRpyCurrentIn("baseRpyCurrentIn", m_baseRpyCurrent),
     m_rsvelIn("rsvel", m_rsvel),
     m_rstorqueIn("rstorque", m_rstorque),
     m_servoStateIn("servoState", m_servoState),
@@ -66,6 +67,7 @@ RTC::ReturnCode_t HrpsysSeqStateROSBridgeImpl::onInitialize()
   addInPort("mcangle", m_mcangleIn);
   addInPort("baseTform", m_baseTformIn);
   addInPort("baseRpy", m_baseRpyIn);
+  addInPort("baseRpyCurrent", m_baseRpyCurrentIn);
   addInPort("rsvel", m_rsvelIn);
   addInPort("rstorque", m_rstorqueIn);
   addInPort("rszmp", m_rszmpIn);
@@ -274,6 +276,9 @@ RTC::ReturnCode_t HrpsysSeqStateROSBridgeImpl::onInitialize()
     m_baseRpy.data.r = rpy[0];
     m_baseRpy.data.p = rpy[1];
     m_baseRpy.data.y = rpy[2];
+    m_baseRpyCurrent.data.r = rpy[0]; // same as baseRpy
+    m_baseRpyCurrent.data.p = rpy[1];
+    m_baseRpyCurrent.data.y = rpy[2]; 
   }
 
   // End effector setting from conf file

--- a/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridgeImpl.h
+++ b/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridgeImpl.h
@@ -189,6 +189,12 @@ class HrpsysSeqStateROSBridgeImpl  : public RTC::DataFlowComponentBase
     std::string link_name;
   } COPLinkInfo;
   std::map<std::string, COPLinkInfo> cop_link_info;
+  
+  typedef struct  {
+    std::string name, target, base;
+    tf::Transform transform;
+  } EndEffectorInfo;
+  std::map<std::string, EndEffectorInfo> ee_info;
 
   double dt;
 

--- a/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridgeImpl.h
+++ b/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridgeImpl.h
@@ -125,7 +125,9 @@ class HrpsysSeqStateROSBridgeImpl  : public RTC::DataFlowComponentBase
 
   // for imu topic
   TimedOrientation3D m_baseRpy;
+  TimedOrientation3D m_baseRpyCurrent;
   InPort<TimedOrientation3D> m_baseRpyIn;
+  InPort<TimedOrientation3D> m_baseRpyCurrentIn;
 
   TimedDoubleSeq m_rsvel;
   InPort<TimedDoubleSeq> m_rsvelIn;


### PR DESCRIPTION
This PR is a part of modifications to reduce tf broadcaster/listener and rate of tf topics. 
- Combine tf publication of odom_init, ground, which are originally in jsk_footstep_controller/footcoords.
  (cf. https://github.com/jsk-ros-pkg/jsk_control/tree/master/jsk_footstep_controller)
- Publish imu_rootlink, which publish orientation/angular_velocity/acceleration relative to root_link though imu is relative to parent_link.
