### PR TITLE
add queue_size

### DIFF
--- a/hrpsys_ros_bridge/scripts/collision_state.py
+++ b/hrpsys_ros_bridge/scripts/collision_state.py
@@ -178,8 +178,8 @@ if __name__ == '__main__':
 
     try:
         rospy.init_node('collision_state_diagnostics')
-        pub_diagnostics = rospy.Publisher('diagnostics', DiagnosticArray)
-        pub_collision = rospy.Publisher('collision_detector_marker_array', MarkerArray)
+        pub_diagnostics = rospy.Publisher('diagnostics', DiagnosticArray, queue_size=1)
+        pub_collision = rospy.Publisher('collision_detector_marker_array', MarkerArray, queue_size=1)
 
         r = rospy.Rate(50)
 


### PR DESCRIPTION
```
/opt/ros/indigo/share/hrpsys_ros_bridge/scripts/collision_state.py:181: SyntaxWarning: The publisher should be created with an explicit keyword argument 'queue_size'. Please see http://wiki.ros.org/rospy/Overview/Publishers%20and%20Subscribers for more information.
  pub_diagnostics = rospy.Publisher('diagnostics', DiagnosticArray)
/opt/ros/indigo/share/hrpsys_ros_bridge/scripts/collision_state.py:182: SyntaxWarning: The publisher should be created with an explicit keyword argument 'queue_size'. Please see http://wiki.ros.org/rospy/Overview/Publishers%20and%20Subscribers for more information.
  pub_collision = rospy.Publisher('collision_detector_marker_array', MarkerArray)
```