### PR TITLE
Publish ground transform in HrpsysSeqStateROSBridge

### DIFF
--- a/hrpsys_ros_bridge/catkin.cmake
+++ b/hrpsys_ros_bridge/catkin.cmake
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(hrpsys_ros_bridge)
 
 # call catkin depends
-find_package(catkin REQUIRED COMPONENTS rtmbuild roscpp rostest sensor_msgs robot_state_publisher actionlib control_msgs tf camera_info_manager hrpsys_tools image_transport dynamic_reconfigure nav_msgs geometry_msgs pr2_controllers_msgs pr2_msgs) # robot_monitor
+find_package(catkin REQUIRED COMPONENTS rtmbuild roscpp rostest sensor_msgs robot_state_publisher actionlib control_msgs tf camera_info_manager hrpsys_tools image_transport dynamic_reconfigure nav_msgs geometry_msgs pr2_controllers_msgs pr2_msgs eigen_conversions tf_conversions) # robot_monitor
 find_package(hrpsys QUIET) # on indigo, hrpsys is not ros package
 if(NOT ${hrpsys_FOUND})
   find_package(PkgConfig)

--- a/hrpsys_ros_bridge/package.xml
+++ b/hrpsys_ros_bridge/package.xml
@@ -62,6 +62,8 @@
   <build_depend>tf</build_depend>
   <build_depend>visualization_msgs</build_depend>
   <build_depend>geometry_msgs</build_depend>
+  <build_depend>eigen_conversions</build_depend>
+  <build_depend>tf_conversions</build_depend>
 
   <run_depend>actionlib</run_depend>
   <run_depend>camera_info_manager</run_depend>
@@ -92,6 +94,8 @@
   <run_depend>tf</run_depend>
   <run_depend>visualization_msgs</run_depend>
   <run_depend>geometry_msgs</run_depend>
+  <run_depend>eigen_conversions</run_depend>
+  <run_depend>tf_conversions</run_depend>  
   <!-- <test_depend>hrpsys</test_depend> -->
   <!-- <test_depend>hrpsys_tools</test_depend> -->
   <!-- <test_depend>openrtm_tools</test_depend> -->

--- a/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.cpp
+++ b/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.cpp
@@ -36,12 +36,17 @@ HrpsysSeqStateROSBridge::HrpsysSeqStateROSBridge(RTC::Manager* manager) :
   use_sim_time(false), use_hrpsys_time(false),
   joint_trajectory_server(nh, "fullbody_controller/joint_trajectory_action", false),
   follow_joint_trajectory_server(nh, "fullbody_controller/follow_joint_trajectory_action", false),
-  HrpsysSeqStateROSBridgeImpl(manager), follow_action_initialized(false), prev_odom_acquired(false)
+  HrpsysSeqStateROSBridgeImpl(manager), follow_action_initialized(false), prev_odom_acquired(false),
+  update_odom_init_flag(false), prev_lfoot_contact_state(false), prev_rfoot_contact_state(false),
+  is_robot_on_ground(false)
 {
   // ros
   ros::NodeHandle pnh("~");
   pnh.param("publish_sensor_transforms", publish_sensor_transforms, true);
   pnh.param("publish_odom_transform", publish_odom_transform, true);
+  pnh.param("publish_odom_init_transform", publish_odom_init_transform, true);
+  pnh.param("invert_odom_init_tf", invert_odom_init_tf, true);
+  pnh.param("check_robot_is_on_ground", check_robot_is_on_ground, true);
   pnh.param("tf_rate", tf_rate, 50.0);
   periodic_update_timer = pnh.createTimer(ros::Duration(1.0 / tf_rate), boost::bind(&HrpsysSeqStateROSBridge::periodicTimerCallback, this, _1));
   
@@ -54,10 +59,14 @@ HrpsysSeqStateROSBridge::HrpsysSeqStateROSBridge(RTC::Manager* manager) :
   joint_state_pub = nh.advertise<sensor_msgs::JointState>("joint_states", 1);
   joint_controller_state_pub = nh.advertise<pr2_controllers_msgs::JointTrajectoryControllerState>("/fullbody_controller/state", 1);
   trajectory_command_sub = nh.subscribe("/fullbody_controller/command", 1, &HrpsysSeqStateROSBridge::onTrajectoryCommandCB, this);
+  odom_init_trigger_sub = nh.subscribe("/odom_init_trigger", 1, &HrpsysSeqStateROSBridge::odomInitTriggerCB, this);
   mot_states_pub = nh.advertise<hrpsys_ros_bridge::MotorStates>("/motor_states", 1);
   odom_pub = nh.advertise<nav_msgs::Odometry>("/odom", 1);
   imu_pub = nh.advertise<sensor_msgs::Imu>("/imu", 1);
+  odom_init_pose_stamped_pub = nh.advertise<geometry_msgs::PoseStamped>("/odom_init_pose_stamped", 1, true);
+  odom_init_transform_pub = nh.advertise<geometry_msgs::TransformStamped>("/odom_init_transform", 1, true);
   odom_transform = tf::Transform(tf::Quaternion(0, 0, 0, 1), tf::Vector3(0, 0, 0));
+  odom_init_transform = tf::Transform(tf::Quaternion(0, 0, 0, 1), tf::Vector3(0, 0, 0));
   imu_floor_transform = tf::Transform(tf::Quaternion(0, 0, 0, 1), tf::Vector3(0, 0, 0));
   // is use_sim_time is set and no one publishes clock, publish clock time
   use_sim_time = ros::Time::isSimTime();
@@ -550,6 +559,7 @@ RTC::ReturnCode_t HrpsysSeqStateROSBridge::onExecute(RTC::UniqueId ec_id)
     { // update odometry topics
       boost::mutex::scoped_lock lock(odom_mutex);
       updateOdometry(base, odom_stamp);
+      updateOdomInit(odom_stamp);      
     }
 
   }  // end: m_baseTformIn
@@ -725,6 +735,8 @@ RTC::ReturnCode_t HrpsysSeqStateROSBridge::onExecute(RTC::UniqueId ec_id)
         actCSs.header.stamp = tm_on_execute;
       }
       int limb_size = m_actContactStates.data.length();
+      bool lfoot_cs = prev_lfoot_contact_state;
+      bool rfoot_cs = prev_rfoot_contact_state;
       actCSs.states.resize(limb_size);
       for ( unsigned int i = 0; i < limb_size ; i++ ){
         hrpsys_ros_bridge::ContactState s;
@@ -736,7 +748,14 @@ RTC::ReturnCode_t HrpsysSeqStateROSBridge::onExecute(RTC::UniqueId ec_id)
         actCSs.states[i].header.stamp = actCSs.header.stamp;
         actCSs.states[i].header.frame_id = m_rsforceName[i*2];
         actCSs.states[i].state = s;
+        // check contact states for robot leg sensors (TODO: do not hard-code sensor name)
+        if (actCSs.states[i].header.frame_id == "lfsensor") {
+          lfoot_cs = m_actContactStates.data[i];
+        } else if (actCSs.states[i].header.frame_id == "rfsensor") {
+          rfoot_cs = m_actContactStates.data[i];
+        }
       }
+      checkFootContactState(lfoot_cs, rfoot_cs); // check does robot stand on the ground and set update_odom_init_flag
       act_contact_states_pub.publish(actCSs);
     }
     catch(const std::runtime_error &e)
@@ -926,9 +945,57 @@ void HrpsysSeqStateROSBridge::updateOdometry(const tf::Transform &base, const ro
   }
 }
 
+bool HrpsysSeqStateROSBridge::checkFootContactState(bool lfoot_contact_state, bool rfoot_contact_state)
+{
+  if (check_robot_is_on_ground) { // this function does nothing when check_robot_is_on_ground is false
+    if ((!prev_lfoot_contact_state && lfoot_contact_state)
+        or (!prev_rfoot_contact_state && rfoot_contact_state)) {
+      if (!is_robot_on_ground) {
+        is_robot_on_ground = true;
+        update_odom_init_flag = true; // update odom_init when robot stands on the ground
+      }
+    } else if (!lfoot_contact_state && !rfoot_contact_state && is_robot_on_ground) {
+      is_robot_on_ground = false;
+    }
+    prev_lfoot_contact_state = lfoot_contact_state;
+    prev_rfoot_contact_state = rfoot_contact_state;
+  }
+}
+
+void HrpsysSeqStateROSBridge::updateOdomInit(const ros::Time &stamp)
+{
+  if (update_odom_init_flag) {
+    // publish odom_init topics
+    // whether invert_odom_init is true or not odom_init_pose_stamped and odom_init_transform is described in odom coordinates.
+    geometry_msgs::TransformStamped ros_odom_init_coords;
+    geometry_msgs::PoseStamped ros_odom_init_pose_stamped;
+    // ignore z height and roll/pitch angle transform from odom assuming odom_init is on the flat ground
+    tf::Matrix3x3 odom_pose_matrix(odom_transform.getRotation());
+    double odom_roll, odom_pitch, odom_yaw;
+    odom_pose_matrix.getRPY(odom_roll, odom_pitch, odom_yaw);
+    // double odom_init_yaw = atan2(odom_pose_matrix[1][0], odom_pose_matrix[0][0]); // ref: pcl::getEulerAngles
+    odom_init_transform.setOrigin(tf::Vector3(odom_transform.getOrigin()[0], odom_transform.getOrigin()[1], 0.0));
+    odom_init_transform.setRotation(tf::Quaternion(tf::Vector3(0, 0, 1), odom_yaw));
+    // transform (not be affected by invert_odom_init_tf)
+    ros_odom_init_coords.header.stamp = stamp;
+    ros_odom_init_coords.header.frame_id = "/odom";
+    ros_odom_init_coords.child_frame_id = "/odom_init";
+    tf::transformTFToMsg(odom_init_transform, ros_odom_init_coords.transform);
+    odom_init_transform_pub.publish(ros_odom_init_coords);
+    // pose stamped
+    ros_odom_init_pose_stamped.header = ros_odom_init_coords.header;
+    ros_odom_init_pose_stamped.pose.position.x = ros_odom_init_coords.transform.translation.x;
+    ros_odom_init_pose_stamped.pose.position.y = ros_odom_init_coords.transform.translation.y;
+    ros_odom_init_pose_stamped.pose.position.z = ros_odom_init_coords.transform.translation.z;
+    ros_odom_init_pose_stamped.pose.orientation = ros_odom_init_coords.transform.rotation;
+    odom_init_pose_stamped_pub.publish(ros_odom_init_pose_stamped);
+    update_odom_init_flag = false;
+  }
+}
+
 void HrpsysSeqStateROSBridge::pushOdometryTransforms(const ros::Time &stamp, std::vector<geometry_msgs::TransformStamped> &tf_transforms)
 {
-  geometry_msgs::TransformStamped ros_odom_to_body_coords;
+  geometry_msgs::TransformStamped ros_odom_to_body_coords, ros_odom_init_coords;
   // odom
   if(publish_odom_transform) {
     ros_odom_to_body_coords.header.stamp = stamp;
@@ -937,6 +1004,26 @@ void HrpsysSeqStateROSBridge::pushOdometryTransforms(const ros::Time &stamp, std
     tf::transformTFToMsg(odom_transform, ros_odom_to_body_coords.transform);
     tf_transforms.push_back(ros_odom_to_body_coords);
   }
+  // odom_init
+  if (publish_odom_init_transform) {
+    ros_odom_init_coords.header.stamp = stamp;
+    if (invert_odom_init_tf) {
+      ros_odom_init_coords.header.frame_id ="/odom_init";
+      ros_odom_init_coords.child_frame_id =  "/odom";
+      tf::transformTFToMsg(odom_init_transform.inverse(), ros_odom_init_coords.transform);
+    } else {
+      ros_odom_init_coords.header.frame_id = "/odom";
+      ros_odom_init_coords.child_frame_id = "/odom_init";
+      tf::transformTFToMsg(odom_init_transform, ros_odom_init_coords.transform);
+    }
+    tf_transforms.push_back(ros_odom_init_coords);
+  }
+}
+
+void HrpsysSeqStateROSBridge::odomInitTriggerCB(const std_msgs::Empty &trigger)
+{
+  boost::mutex::scoped_lock lock(odom_mutex);
+  update_odom_init_flag = true; // forcely update odom_init
 }
 
 void HrpsysSeqStateROSBridge::updateImu(tf::Transform &base, bool is_base_valid, const ros::Time &stamp)

--- a/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.h
+++ b/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.h
@@ -91,14 +91,16 @@ class HrpsysSeqStateROSBridge  : public HrpsysSeqStateROSBridgeImpl
   bool checkFootContactState(bool lfoot_contact_state, bool rfoot_contact_state);
   void updateOdomInit(const ros::Time &stamp);
   void pushOdometryTransforms(const ros::Time &stamp, std::vector<geometry_msgs::TransformStamped> &tf_transforms);
-  void odomInitTriggerCB(const std_msgs::Empty &trigger);  
+  void odomInitTriggerCB(const std_msgs::Empty &trigger);
+  bool isLeggedRobot();
+  void updateGroundTransform();
   boost::mutex odom_mutex;
-  tf::Transform odom_transform, odom_init_transform;
+  tf::Transform odom_transform, odom_init_transform, ground_transform;
   bool update_odom_init_flag;
   bool prev_lfoot_contact_state;
   bool prev_rfoot_contact_state;
   bool is_robot_on_ground;
-  bool publish_odom_transform, publish_odom_init_transform, invert_odom_init_tf, check_robot_is_on_ground;
+  bool publish_odom_transform, publish_odom_init_transform, invert_odom_init_tf, check_robot_is_on_ground, publish_ground_transform;
 
   // imu relatives
   void updateImu(tf::Transform &base, bool is_base_valid, const ros::Time &stamp);

--- a/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.h
+++ b/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.h
@@ -86,7 +86,10 @@ class HrpsysSeqStateROSBridge  : public HrpsysSeqStateROSBridgeImpl
 
   // odometry relatives
   void updateOdometry(const tf::Transform &base, const ros::Time &stamp);
+  void pushOdometryTransforms(const ros::Time &stamp, std::vector<geometry_msgs::TransformStamped> &tf_transforms);
+  boost::mutex odom_mutex;
   tf::Transform odom_transform;
+  bool publish_odom_transform;
 
   // imu relatives
   void updateImu(tf::Transform &base, bool is_base_valid, const ros::Time &stamp);

--- a/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.h
+++ b/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.h
@@ -16,6 +16,7 @@
 #include "ros/ros.h"
 #include "rosgraph_msgs/Clock.h"
 #include "std_msgs/Int32.h"
+#include "std_msgs/Empty.h"
 #include "sensor_msgs/JointState.h"
 #include "nav_msgs/Odometry.h"
 #include "geometry_msgs/WrenchStamped.h"
@@ -54,8 +55,9 @@ class HrpsysSeqStateROSBridge  : public HrpsysSeqStateROSBridgeImpl
                                hrpsys_ros_bridge::SetSensorTransformation::Response& res);
  private:
   ros::NodeHandle nh;
-  ros::Publisher joint_state_pub, joint_controller_state_pub, mot_states_pub, diagnostics_pub, clock_pub, zmp_pub, ref_cp_pub, act_cp_pub, odom_pub, imu_pub, em_mode_pub, ref_contact_states_pub, act_contact_states_pub;
-  ros::Subscriber trajectory_command_sub;
+  ros::Publisher joint_state_pub, joint_controller_state_pub, mot_states_pub, diagnostics_pub, clock_pub, zmp_pub, ref_cp_pub, act_cp_pub, odom_pub, imu_pub,
+    em_mode_pub, ref_contact_states_pub, act_contact_states_pub, odom_init_pose_stamped_pub, odom_init_transform_pub;
+  ros::Subscriber trajectory_command_sub, odom_init_trigger_sub;
   std::vector<ros::Publisher> fsensor_pub, cop_pub;
   actionlib::SimpleActionServer<pr2_controllers_msgs::JointTrajectoryAction> joint_trajectory_server;
   actionlib::SimpleActionServer<control_msgs::FollowJointTrajectoryAction> follow_joint_trajectory_server;
@@ -86,10 +88,17 @@ class HrpsysSeqStateROSBridge  : public HrpsysSeqStateROSBridgeImpl
 
   // odometry relatives
   void updateOdometry(const tf::Transform &base, const ros::Time &stamp);
+  bool checkFootContactState(bool lfoot_contact_state, bool rfoot_contact_state);
+  void updateOdomInit(const ros::Time &stamp);
   void pushOdometryTransforms(const ros::Time &stamp, std::vector<geometry_msgs::TransformStamped> &tf_transforms);
+  void odomInitTriggerCB(const std_msgs::Empty &trigger);  
   boost::mutex odom_mutex;
-  tf::Transform odom_transform;
-  bool publish_odom_transform;
+  tf::Transform odom_transform, odom_init_transform;
+  bool update_odom_init_flag;
+  bool prev_lfoot_contact_state;
+  bool prev_rfoot_contact_state;
+  bool is_robot_on_ground;
+  bool publish_odom_transform, publish_odom_init_transform, invert_odom_init_tf, check_robot_is_on_ground;
 
   // imu relatives
   void updateImu(tf::Transform &base, bool is_base_valid, const ros::Time &stamp);

--- a/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.h
+++ b/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.h
@@ -73,14 +73,15 @@ class HrpsysSeqStateROSBridge  : public HrpsysSeqStateROSBridgeImpl
 
   ros::Subscriber clock_sub;
 
-  std::map<std::string, geometry_msgs::Transform> sensor_transformations;
-  boost::mutex sensor_transformation_mutex;
-
   nav_msgs::Odometry prev_odom;
   bool prev_odom_acquired;
   hrp::Vector3 prev_rpy;
   void clock_cb(const rosgraph_msgs::ClockPtr& str) {};
 
+  double tf_rate;
+  ros::Timer periodic_update_timer;
+  void periodicTimerCallback(const ros::TimerEvent& event);
+  
   bool follow_action_initialized;
 
   // odometry relatives
@@ -89,7 +90,14 @@ class HrpsysSeqStateROSBridge  : public HrpsysSeqStateROSBridgeImpl
 
   // imu relatives
   void updateImu(tf::Transform &base, bool is_base_valid, const ros::Time &stamp);
-  tf::Transform imu_floor_transform; 
+  void pushImuTransform(const ros::Time &stamp, std::vector<geometry_msgs::TransformStamped> &tf_transforms);
+  boost::mutex imu_mutex;
+  tf::Transform imu_floor_transform;
+  
+  // sensor relatives
+  void pushSensorTransform(const ros::Time &stamp, std::vector<geometry_msgs::TransformStamped> &tf_transforms);
+  std::map<std::string, geometry_msgs::Transform> sensor_transformations;
+  boost::mutex sensor_transformation_mutex;
 
 };
 

--- a/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.h
+++ b/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.h
@@ -82,12 +82,15 @@ class HrpsysSeqStateROSBridge  : public HrpsysSeqStateROSBridgeImpl
   void clock_cb(const rosgraph_msgs::ClockPtr& str) {};
 
   bool follow_action_initialized;
-  
+
   // odometry relatives
-  void updateOdometry(const hrp::Vector3 &trans, const hrp::Matrix33 &R, const ros::Time &stamp);
+  void updateOdometry(const tf::Transform &base, const ros::Time &stamp);
+  tf::Transform odom_transform;
 
   // imu relatives
   void updateImu(tf::Transform &base, bool is_base_valid, const ros::Time &stamp);
+  tf::Transform imu_floor_transform; 
+
 };
 
 

--- a/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.h
+++ b/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.h
@@ -82,6 +82,12 @@ class HrpsysSeqStateROSBridge  : public HrpsysSeqStateROSBridgeImpl
   void clock_cb(const rosgraph_msgs::ClockPtr& str) {};
 
   bool follow_action_initialized;
+  
+  // odometry relatives
+  void updateOdometry(const hrp::Vector3 &trans, const hrp::Matrix33 &R, const ros::Time &stamp);
+
+  // imu relatives
+  void updateImu(tf::Transform &base, bool is_base_valid, const ros::Time &stamp);
 };
 
 

--- a/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridgeImpl.cpp
+++ b/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridgeImpl.cpp
@@ -5,6 +5,7 @@
  * $Id$ 
  */
 #include "HrpsysSeqStateROSBridgeImpl.h"
+#include <tf_conversions/tf_eigen.h>
 
 // Module specification
 // <rtc-template block="module_spec">
@@ -284,14 +285,31 @@ RTC::ReturnCode_t HrpsysSeqStateROSBridgeImpl::onInitialize()
     for (size_t i = 0; i < num; i++) {
       // Parse end-effector information from conf
       std::string ee_name, ee_target, ee_base;
+      tf::Transform ee_transform;
+      EndEffectorInfo tmp_ee_info;
       coil::stringTo(ee_name, end_effectors_str[i*prop_num].c_str());
       coil::stringTo(ee_target, end_effectors_str[i*prop_num+1].c_str());
       coil::stringTo(ee_base, end_effectors_str[i*prop_num+2].c_str());
+      // make end-effector-info
       hrp::Vector3 eep;
       for (size_t j = 0; j < 3; j++) {
         coil::stringTo(eep(j), end_effectors_str[i*prop_num+3+j].c_str());
       }
+      double eerot[4]; // rotation in VRML is represented by axis + angle
+      for (int j = 0; j < 4; j++ ) {
+        coil::stringTo(eerot[j], end_effectors_str[i*prop_num+6+j].c_str());
+      }
+      Eigen::Affine3d ee_transform_matrix = (Eigen::Translation3d(eep(0), eep(1), eep(2)) *
+                                             Eigen::AngleAxisd(eerot[3], hrp::Vector3(eerot[0], eerot[1], eerot[2])));
+      tmp_ee_info.name = ee_name;
+      tmp_ee_info.target = ee_target;
+      tmp_ee_info.base = ee_base;
+      tf::transformEigenToTF(ee_transform_matrix, tmp_ee_info.transform);
+      ee_info.insert(std::pair<std::string, EndEffectorInfo>(ee_name , tmp_ee_info));
       std::cerr << "[" << m_profile.instance_name << "] End Effector [" << ee_name << "]" << ee_target << " " << ee_base << std::endl;
+      std::cerr << "[" << m_profile.instance_name << "]   translation = " << tmp_ee_info.transform.getOrigin().x() << ", " << tmp_ee_info.transform.getOrigin().y() << ", " << tmp_ee_info.transform.getOrigin().z() << std::endl;
+      std::cerr << "[" << m_profile.instance_name << "]   rotation = " <<  tmp_ee_info.transform.getRotation().getAxis().x() << ", " << tmp_ee_info.transform.getRotation().getAxis().y() << ", "
+                << tmp_ee_info.transform.getRotation().getAxis().z() << ", " << tmp_ee_info.transform.getRotation().getAngle() << std::endl;
       // Find pair between end-effector information and force sensor name
       bool is_sensor_exists = false;
       std::string sensor_name;

--- a/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridgeImpl.h
+++ b/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridgeImpl.h
@@ -190,6 +190,12 @@ class HrpsysSeqStateROSBridgeImpl  : public RTC::DataFlowComponentBase
   } COPLinkInfo;
   std::map<std::string, COPLinkInfo> cop_link_info;
 
+  typedef struct  {
+    std::string name, target, base;
+    tf::Transform transform;
+  } EndEffectorInfo;
+  std::map<std::string, EndEffectorInfo> ee_info;
+
   double dt;
 
  private:


### PR DESCRIPTION
This PR is divided part 5 of #893 
This PR includes following new function:
- Publish ground tf, which is midcoords of leg end-coords and previously published in footcoords (ref. https://github.com/jsk-ros-pkg/jsk_control/tree/master/jsk_footstep_controller ). This function is enabled by `~publish_ground_transform` param.
- Add end-effector information structure to HrpsysSeqStateROSBridgeImpl, which is needed to use end-effector coordinates of legs for ground transformation.
