### PR TITLE
add more mesage to prevent confusion

### DIFF
--- a/hrpsys_ros_bridge/scripts/collision_state.py
+++ b/hrpsys_ros_bridge/scripts/collision_state.py
@@ -178,8 +178,8 @@ if __name__ == '__main__':
 
     try:
         rospy.init_node('collision_state_diagnostics')
-        pub_diagnostics = rospy.Publisher('diagnostics', DiagnosticArray)
-        pub_collision = rospy.Publisher('collision_detector_marker_array', MarkerArray)
+        pub_diagnostics = rospy.Publisher('diagnostics', DiagnosticArray, queue_size=1)
+        pub_collision = rospy.Publisher('collision_detector_marker_array', MarkerArray, queue_size=1)
 
         r = rospy.Rate(50)
 

--- a/hrpsys_ros_bridge/scripts/diagnostics.py
+++ b/hrpsys_ros_bridge/scripts/diagnostics.py
@@ -86,7 +86,7 @@ if __name__ == '__main__':
         rospy.init_node('operation_mode_diagnostics')
         sub = rospy.Subscriber('motor_states', MotorStates, states_cb)
         sub_emergency_mode = rospy.Subscriber('emergency_mode', Int32, emergency_mode_cb)
-        pub = rospy.Publisher('diagnostics', DiagnosticArray)
+        pub = rospy.Publisher('diagnostics', DiagnosticArray, queue_size=1)
         r = rospy.Rate(10)
         emergency_mode = None
         while not rospy.is_shutdown():

--- a/hrpsys_ros_bridge/scripts/hrpsys_profile.py
+++ b/hrpsys_ros_bridge/scripts/hrpsys_profile.py
@@ -85,7 +85,7 @@ if __name__ == '__main__':
         rtc_init()
 
         rospy.init_node('hrpsys_profile_diagnostics')
-        pub = rospy.Publisher('diagnostics', DiagnosticArray)
+        pub = rospy.Publisher('diagnostics', DiagnosticArray, queue_size=1)
 
         r = rospy.Rate(1) # 10hz
 

--- a/openrtm_tools/src/openrtm_tools/rtmlaunch.py
+++ b/openrtm_tools/src/openrtm_tools/rtmlaunch.py
@@ -7,6 +7,7 @@ import sys
 import os
 import time
 import optparse
+import socket
 
 from xml.dom.minidom import parse
 
@@ -224,10 +225,26 @@ def main():
     else:
         nameserver = os.getenv("RTCTREE_NAMESERVERS")
 
-    print >>sys.stderr, "[rtmlaunch] RTCTREE_NAMESERVERS", nameserver,  os.getenv("RTCTREE_NAMESERVERS")
-    print >>sys.stderr, "[rtmlaunch] SIMULATOR_NAME", os.getenv("SIMULATOR_NAME","Simulator")
+    print >>sys.stderr, "\033[32m[rtmlaunch] RTCTREE_NAMESERVERS", nameserver,  os.getenv("RTCTREE_NAMESERVERS"), "\033[0m"
+    print >>sys.stderr, "\033[32m[rtmlaunch] SIMULATOR_NAME", os.getenv("SIMULATOR_NAME","Simulator"), "\033[0m"
 
-    tree = rtctree.tree.RTCTree()
+    try:
+        tree = rtctree.tree.RTCTree()
+    except Exception, e:
+        print >>sys.stderr, "\033[31m[rtmlaunch] Could not start rtmlaunch.py, Caught exception (", e, ")\033[0m"
+        # check if host is connected
+        try:
+            hostname = nameserver.split(':')[0]
+            ip_address = socket.gethostbyname(hostname)
+        except Exception, e:
+            print >>sys.stderr, "\033[31m[rtmlaunch] .. Could not find IP address of ", hostname, ", Caught exception (", e, ")\033[0m"
+            print >>sys.stderr, "\033[31m[rtmlaunch] .. Please check /etc/hosts or DNS setup\033[0m"
+            return 1
+        # in this case, it is likely you forget to run name serveer
+        print >>sys.stderr, "\033[31m[rtmlaunch] .. Could not connect to NameServer at ", nameserver, ", Caught exception (", e, ")\033[0m"
+        print >>sys.stderr, "\033[31m[rtmlaunch] .. Please make sure that you have NameServer running at %s/`\033[0m"%(nameserver)
+        print >>sys.stderr, "\033[31m[rtmlaunch] .. You can check with `rtls %s/`\033[0m"%(nameserver)
+        return 1
     while 1:
         print >>sys.stderr, "[rtmlaunch] check connection/activation"
         rtconnect(nameserver, parser.getElementsByTagName("rtconnect"), tree)


### PR DESCRIPTION
This will output like this, stil confusing...
```
core service [/rosout] found
WARNING: Package name "VSProjects" does not follow the naming conventions. It should start with a lower case letter and only contain lower case letters, digits and underscores.
process[HrpsysSeqStateROSBridge-1]: started with pid [27970]
process[HrpsysJointTrajectoryBridge-2]: started with pid [27971]
process[hrpsys_state_publisher-3]: started with pid [27988]
process[hrpsys_ros_diagnostics-4]: started with pid [28011]
process[diagnostic_aggregator-5]: started with pid [28024]
process[hrpsys_profile-6]: started with pid [28029]
process[sensor_ros_bridge_connect-7]: started with pid [28056]
process[rtmlaunch_hrpsys_ros_bridge-8]: started with pid [28060]
process[SequencePlayerServiceROSBridge-9]: started with pid [28066]
process[DataLoggerServiceROSBridge-10]: started with pid [28076]
process[ForwardKinematicsServiceROSBridge-11]: started with pid [28085]
process[StateHolderServiceROSBridge-12]: started with pid [28099]
process[robot_pose_ekf-13]: started with pid [28105]
process[base_footprint_rootlink-14]: started with pid [28107]
process[CollisionDetectorComp-15]: started with pid [28132]
process[rtmlaunch_collision_detector-16]: started with pid [28140]
[ERROR] Connection Failed with the Nameserver (hostname=hiro014 port=15005).
Make sure the hostname is correct and the Nameserver is running.
CORBA.TRANSIENT(omniORB.TRANSIENT_ConnectFailed, CORBA.COMPLETED_NO)
process[collision_state-17]: started with pid [28153]
[hrpsys_profile-6] process has died [pid 28029, exit code 1, cmd /home/k-okada/catkin_ws/ws_rtmros/src/rtmros_common/hrpsys_ros_bridge/scripts/hrpsys_profile.py -ORBInitRef NameService=corbaloc:iiop:hiro014:15005/NameService __name:=hrpsys_profile __log:=/home/k-okada/.ros/log/fefbfe9e-b5c5-11e5-aa92-68f728079ca1/hrpsys_profile-6.log].
log file: /home/k-okada/.ros/log/fefbfe9e-b5c5-11e5-aa92-68f728079ca1/hrpsys_profile-6*.log
[sensor_ros_bridge_connect.py]  start
configuration ORB with hiro014:15005
;;
;; Could not open /dev/console for writing.
;;
open: Permission denied
[ERROR] Connection Failed with the Nameserver (hostname=hiro014 port=15005).
Make sure the hostname is correct and the Nameserver is running.
CORBA.TRANSIENT(omniORB.TRANSIENT_ConnectFailed, CORBA.COMPLETED_NO)
terminate called after throwing an instance of 'CORBA::BAD_PARAM'
[sensor_ros_bridge_connect-7] process has died [pid 28056, exit code 1, cmd /home/k-okada/catkin_ws/ws_rtmros/src/rtmros_common/hrpsys_ros_bridge/scripts/sensor_ros_bridge_connect.py /home/k-okada/catkin_ws/ws_rtmros/src/rtmros_hironx/hironx_ros_bridge/models/kawada-hironx.dae RobotHardware0 HrpsysSeqStateROSBridge0 hiro014 -ORBInitRef NameService=corbaloc:iiop:hiro014:15005/NameService __name:=sensor_ros_bridge_connect __log:=/home/k-okada/.ros/log/fefbfe9e-b5c5-11e5-aa92-68f728079ca1/sensor_ros_bridge_connect-7.log].
log file: /home/k-okada/.ros/log/fefbfe9e-b5c5-11e5-aa92-68f728079ca1/sensor_ros_bridge_connect-7*.log
[ WARN] [1452404111.885632687]: [HrpsysSeqStateROSBridge] use_hrpsys_time
[rtmlaunch] starting...  /home/k-okada/catkin_ws/ws_rtmros/src/rtmros_common/hrpsys_ros_bridge/launch/hrpsys_ros_bridge.launch
[CollisionDetectorComp-15] process has died [pid 28132, exit code -6, cmd /opt/ros/indigo/lib/hrpsys/CollisionDetectorComp -o corba.nameservers:hiro014:15005 -o naming.formats:%n.rtc -o exec_cxt.periodic.type:PeriodicExecutionContext -o exec_cxt.periodic.rate:2000 -o logger.file_name:/tmp/collision_detector%p.log -o example.CollisionDetector.config_file:/home/k-okada/catkin_ws/ws_rtmros/src/rtmros_hironx/hironx_ros_bridge/conf/kawada-hironx.conf __name:=CollisionDetectorComp __log:=/home/k-okada/.ros/log/fefbfe9e-b5c5-11e5-aa92-68f728079ca1/CollisionDetectorComp-15.log].
log file: /home/k-okada/.ros/log/fefbfe9e-b5c5-11e5-aa92-68f728079ca1/CollisionDetectorComp-15*.log
[rtmlaunch] RTCTREE_NAMESERVERS localhost:15003 localhost:15003 
[rtmlaunch] SIMULATOR_NAME RobotHardware0 
[rtmlaunch] Cloud not start rtmlaunch.py, Caught exception ( Invalid CORBA naming service: localhost:15003 )
[rtmlaunch] .. Colud not connect to NameServer at  localhost:15003 , Caught exception ( Invalid CORBA naming service: localhost:15003 )
[rtmlaunch] .. Please make sure that you have NameServer running at localhost:15003/`
[rtmlaunch] .. You can check wich `rtls localhost:15003/`
[rtmlaunch_hrpsys_ros_bridge-8] process has finished cleanly
log file: /home/k-okada/.ros/log/fefbfe9e-b5c5-11e5-aa92-68f728079ca1/rtmlaunch_hrpsys_ros_bridge-8*.log
[rtmlaunch] starting...  /home/k-okada/catkin_ws/ws_rtmros/src/rtmros_common/hrpsys_ros_bridge/launch/collision_detector.launch
[rtmlaunch] RTCTREE_NAMESERVERS localhost:15003 localhost:15003 
[rtmlaunch] SIMULATOR_NAME RobotHardware0 
[rtmlaunch] Cloud not start rtmlaunch.py, Caught exception ( Invalid CORBA naming service: localhost:15003 )
[rtmlaunch] .. Colud not connect to NameServer at  localhost:15003 , Caught exception ( Invalid CORBA naming service: localhost:15003 )
[rtmlaunch] .. Please make sure that you have NameServer running at localhost:15003/`
[rtmlaunch] .. You can check wich `rtls localhost:15003/`
[ INFO] [1452404112.235739084]: [HrpsysSeqStateROSBridge] @Initilize name : HrpsysSeqStateROSBridge0
[rtmlaunch_collision_detector-16] process has finished cleanly
log file: /home/k-okada/.ros/log/fefbfe9e-b5c5-11e5-aa92-68f728079ca1/rtmlaunch_collision_detector-16*.log
configuration ORB with hiro014:15005
[ERROR] Connection Failed with the Nameserver (hostname=hiro014 port=15005).
Make sure the hostname is correct and the Nameserver is running.
CORBA.TRANSIENT(omniORB.TRANSIENT_ConnectFailed, CORBA.COMPLETED_NO)
[collision_state-17] process has died [pid 28153, exit code 1, cmd /home/k-okada/catkin_ws/ws_rtmros/src/rtmros_common/hrpsys_ros_bridge/scripts/collision_state.py /home/k-okada/catkin_ws/ws_rtmros/src/rtmros_hironx/hironx_ros_bridge/models/kawada-hironx.dae -ORBInitRef NameService=corbaloc:iiop:hiro014:15005/NameService __name:=collision_state __log:=/home/k-okada/.ros/log/fefbfe9e-b5c5-11e5-aa92-68f728079ca1/collision_state-17.log].
```