### PR TITLE
[hrpsys_ros_bridge] Suppress /tf publishing rate by tf_rate using Timer callback in ros.

### DIFF
--- a/hrpsys_ros_bridge/scripts/hrpsys_seq_state_ros_bridge_relay.py
+++ b/hrpsys_ros_bridge/scripts/hrpsys_seq_state_ros_bridge_relay.py
@@ -1,0 +1,24 @@
+#! /usr/bin/env python
+import rospy
+import tf
+from tf.msg import tfMessage
+
+class HrpsysSeqStateROSBridgeTFRelay:
+    def __init__(self):
+        rospy.init_node("HrpsysSeqStateROSBridgeTFRelay", anonymous=True)
+        rospy.Subscriber('/tf', tfMessage, self.tf_callback)
+        self.broadcaster = rospy.Publisher("/hrpsys_ros_bridge/tf", tfMessage, queue_size = 100)
+
+    def execute(self):
+        while not rospy.is_shutdown():
+            rospy.spin()
+
+    def tf_callback(self, msg):
+        if msg._connection_header['callerid'] == '/HrpsysSeqStateROSBridge':
+            self.broadcaster.publish(msg)
+                
+if __name__ == '__main__':
+    try:
+        node = HrpsysSeqStateROSBridgeTFRelay()
+        node.execute()
+    except rospy.ROSInterruptException: pass

--- a/hrpsys_ros_bridge/scripts/hrpsys_seq_state_ros_bridge_tf_relay_for_test.py
+++ b/hrpsys_ros_bridge/scripts/hrpsys_seq_state_ros_bridge_tf_relay_for_test.py
@@ -1,4 +1,7 @@
 #! /usr/bin/env python
+
+# This script extracts tf from HrpsysSeqStateROSBridge to test tf rate of HrpsysSeqStateROSBridge in rostest.
+
 import rospy
 import tf
 from tf.msg import tfMessage

--- a/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.h
+++ b/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.h
@@ -73,21 +73,29 @@ class HrpsysSeqStateROSBridge  : public HrpsysSeqStateROSBridgeImpl
 
   ros::Subscriber clock_sub;
 
-  std::map<std::string, geometry_msgs::Transform> sensor_transformations;
-  boost::mutex sensor_transformation_mutex;
-
   nav_msgs::Odometry prev_odom;
   bool prev_odom_acquired;
   hrp::Vector3 prev_rpy;
   void clock_cb(const rosgraph_msgs::ClockPtr& str) {};
 
   bool follow_action_initialized;
+
+  boost::mutex tf_mutex;
+  double tf_rate;
+  ros::Timer periodic_update_timer;
+  std::vector<geometry_msgs::TransformStamped> tf_transforms;
+  void periodicTimerCallback(const ros::TimerEvent& event);
   
   // odometry relatives
   void updateOdometry(const hrp::Vector3 &trans, const hrp::Matrix33 &R, const ros::Time &stamp);
 
   // imu relatives
   void updateImu(tf::Transform &base, bool is_base_valid, const ros::Time &stamp);
+  
+  // sensor relatives
+  void updateSensorTransform(const ros::Time &stamp);
+  std::map<std::string, geometry_msgs::Transform> sensor_transformations;
+  boost::mutex sensor_transformation_mutex;
 };
 
 

--- a/hrpsys_ros_bridge/test/test-samplerobot.test
+++ b/hrpsys_ros_bridge/test/test-samplerobot.test
@@ -8,14 +8,24 @@
     <arg name="RUN_RVIZ" default="false" />
   </include>
 
-  <!-- check if tf is published -->       
-  <param name="hztest_tf/topic" value="/joint_states" />
-  <param name="hztest_tf/wait_time" value="100" />
-  <param name="hztest_tf/hz" value="500.0" />
-  <param name="hztest_tf/hzerror" value="200.0" />
+  <node name="hrpsys_seq_state_ros_bridge_tf_relay" pkg="hrpsys_ros_bridge" type="hrpsys_seq_state_ros_bridge_relay.py"/>
+
+  <!-- check if joint_states is published -->       
+  <param name="hztest_js/topic" value="/joint_states" />
+  <param name="hztest_js/wait_time" value="100" />
+  <param name="hztest_js/hz" value="500.0" />
+  <param name="hztest_js/hzerror" value="200.0" />
+  <param name="hztest_js/test_duration" value="5.0" />
+  <test test-name="hztest_js" pkg="rostest" type="hztest" name="hztest_js" retry="4" />
+
+  <!-- check if tf is published -->
+  <param name="hztest_tf/topic" value="/hrpsys_ros_bridge/tf" />
+  <param name="hztest_tf/wait_time" value="10" />
+  <param name="hztest_tf/hz" value="50.0" />
+  <param name="hztest_tf/hzerror" value="20.0" />
   <param name="hztest_tf/test_duration" value="5.0" />
   <test test-name="hztest_tf" pkg="rostest" type="hztest" name="hztest_tf" retry="4" />
-
+  
   <test test-name="samplerobot" pkg="hrpsys_ros_bridge" type="test-samplerobot.py" retry="4" time-limit="300"/>
 
 </launch>

--- a/hrpsys_ros_bridge/test/test-samplerobot.test
+++ b/hrpsys_ros_bridge/test/test-samplerobot.test
@@ -8,7 +8,7 @@
     <arg name="RUN_RVIZ" default="false" />
   </include>
 
-  <node name="hrpsys_seq_state_ros_bridge_tf_relay" pkg="hrpsys_ros_bridge" type="hrpsys_seq_state_ros_bridge_relay.py"/>
+  <node name="hrpsys_seq_state_ros_bridge_tf_relay" pkg="hrpsys_ros_bridge" type="hrpsys_seq_state_ros_bridge_tf_relay_for_test.py"/>
 
   <!-- check if joint_states is published -->       
   <param name="hztest_js/topic" value="/joint_states" />


### PR DESCRIPTION
Rewrite version of #896
This PR only contain "Suppressing `/tf` rate" functions and new `/tf` functions are not implemented.
I used periodicTimer after all because:
- The purpose of this PR is control publishing rate of `/tf` independently of the realtime loop.
- `/tf`does not have to observe realtime loop strictly if timestamps are correct.
- eigen alignment problem can be avoided by using geometry_msgs::TransformStamped buffer as a member valiable

