### PR TITLE
Enable to set subscription_type, push_policy, and push_rate

### DIFF
--- a/hrpsys_ros_bridge/launch/hrpsys_ros_bridge.launch
+++ b/hrpsys_ros_bridge/launch/hrpsys_ros_bridge.launch
@@ -41,6 +41,8 @@
   <arg name="omniorb_args" default="-ORBInitRef NameService=corbaloc:iiop:$(arg nameserver):$(arg corbaport)/NameService" />
   <arg name="openrtm_args" default='-o "corba.nameservers:$(arg nameserver):$(arg corbaport)" -o "naming.formats:%n.rtc" -o "exec_cxt.periodic.type:PeriodicExecutionContext" -o "exec_cxt.periodic.rate:$(arg periodic_rate)" -o "logger.file_name:/tmp/rtc%p.log"' />
   <arg name="subscription_type" default="new" />
+  <arg name="push_policy" default="all" />
+  <arg name="push_rate" default="50.0" />
   <!-- END:openrtm setting -->
   <arg name="OUTPUT" default="screen"/>
   <env name="LANG" value="C" />
@@ -75,13 +77,15 @@
         if="$(arg USE_HRPSYS_PROFILE)"/>
 
   <node pkg="hrpsys_ros_bridge" name="sensor_ros_bridge_connect" type="sensor_ros_bridge_connect.py"
-        args="$(arg MODEL_FILE) $(arg SIMULATOR_NAME) HrpsysSeqStateROSBridge0 $(arg nameserver) $(arg subscription_type) $(arg omniorb_args)" output="$(arg OUTPUT)"/>
+        args="$(arg MODEL_FILE) $(arg SIMULATOR_NAME) HrpsysSeqStateROSBridge0 $(arg nameserver) $(arg subscription_type) $(arg push_policy) $(arg push_rate) $(arg omniorb_args)" output="$(arg OUTPUT)"/>
   <!-- BEGIN:openrtm connection -->
   <env name="SIMULATOR_NAME" value="$(arg SIMULATOR_NAME)" />
   <env name="SIMULATOR_NAME_ANGLE"    value="$(arg SIMULATOR_NAME_ANGLE)" />
   <env name="SIMULATOR_NAME_VELOCITY" value="$(arg SIMULATOR_NAME_VELOCITY)" />
   <env name="SIMULATOR_NAME_TORQUE"   value="$(arg SIMULATOR_NAME_TORQUE)" />
   <env name="subscription_type" value="$(arg subscription_type)" />
+  <env name="push_policy" value="$(arg push_policy)" />
+  <env name="push_rate" value="$(arg push_rate)" />
   <node name="rtmlaunch_hrpsys_ros_bridge" pkg="openrtm_tools" type="rtmlaunch.py" args="$(find hrpsys_ros_bridge)/launch/hrpsys_ros_bridge.launch USE_COMMON=$(arg USE_COMMON) USE_WALKING=$(arg USE_WALKING) USE_COLLISIONCHECK=$(arg USE_COLLISIONCHECK) USE_IMPEDANCECONTROLLER=$(arg USE_IMPEDANCECONTROLLER) USE_SOFTERRORLIMIT=$(arg USE_SOFTERRORLIMIT) USE_IMAGESENSOR=$(arg USE_IMAGESENSOR) USE_ROBOTHARDWARE=$(arg USE_ROBOTHARDWARE) USE_GRASPCONTROLLER=$(arg USE_GRASPCONTROLLER) USE_SERVOCONTROLLER=$(arg USE_SERVOCONTROLLER) USE_TORQUECONTROLLER=$(arg USE_TORQUECONTROLLER) USE_TORQUEFILTER=$(arg USE_TORQUEFILTER) USE_EMERGENCYSTOPPER=$(arg USE_EMERGENCYSTOPPER) USE_VELOCITY_OUTPUT=$(arg USE_VELOCITY_OUTPUT)" output="$(arg OUTPUT)"/>
 
 
@@ -103,12 +107,12 @@
     <node pkg="hrpsys_ros_bridge" name="StateHolderServiceROSBridge" type="StateHolderServiceROSBridgeComp"
           output="screen" args ="$(arg openrtm_args)" />
 
-    <rtconnect from="$(arg SIMULATOR_NAME_ANGLE).rtc:q"     to="HrpsysSeqStateROSBridge0.rtc:rsangle" subscription_type="$(arg subscription_type)"/>
-    <rtconnect from="$(arg SIMULATOR_NAME_VELOCITY).rtc:dq" to="HrpsysSeqStateROSBridge0.rtc:rsvel" subscription_type="$(arg subscription_type)" if="$(arg USE_VELOCITY_OUTPUT)" />
-    <rtconnect from="$(arg SIMULATOR_NAME_TORQUE).rtc:tau"  to="HrpsysSeqStateROSBridge0.rtc:rstorque" subscription_type="$(arg subscription_type)" unless="$(arg USE_TORQUEFILTER)"/>
+    <rtconnect from="$(arg SIMULATOR_NAME_ANGLE).rtc:q"     to="HrpsysSeqStateROSBridge0.rtc:rsangle" subscription_type="$(arg subscription_type)" push_policy="$(arg push_policy)" push_rate="$(arg push_rate)"/>
+    <rtconnect from="$(arg SIMULATOR_NAME_VELOCITY).rtc:dq" to="HrpsysSeqStateROSBridge0.rtc:rsvel" subscription_type="$(arg subscription_type)" push_policy="$(arg push_policy)" push_rate="$(arg push_rate)" if="$(arg USE_VELOCITY_OUTPUT)" />
+    <rtconnect from="$(arg SIMULATOR_NAME_TORQUE).rtc:tau"  to="HrpsysSeqStateROSBridge0.rtc:rstorque" subscription_type="$(arg subscription_type)" push_policy="$(arg push_policy)" push_rate="$(arg push_rate)" unless="$(arg USE_TORQUEFILTER)"/>
     <rtconnect from="StateHolderServiceROSBridge.rtc:StateHolderService" to="sh.rtc:StateHolderService"  subscription_type="new"/>
-    <rtconnect from="sh.rtc:baseTformOut" to="HrpsysSeqStateROSBridge0.rtc:baseTform" subscription_type="$(arg subscription_type)" unless="$(arg USE_WALKING)"/>
-    <rtconnect from="sh.rtc:qOut" to="HrpsysSeqStateROSBridge0.rtc:mcangle" subscription_type="$(arg subscription_type)"/>
+    <rtconnect from="sh.rtc:baseTformOut" to="HrpsysSeqStateROSBridge0.rtc:baseTform" subscription_type="$(arg subscription_type)" push_policy="$(arg push_policy)" push_rate="$(arg push_rate)" unless="$(arg USE_WALKING)"/>
+    <rtconnect from="sh.rtc:qOut" to="HrpsysSeqStateROSBridge0.rtc:mcangle" subscription_type="$(arg subscription_type)" push_policy="$(arg push_policy)" push_rate="$(arg push_rate)"/>
     <rtconnect from="HrpsysSeqStateROSBridge0.rtc:SequencePlayerService" to="seq.rtc:SequencePlayerService" subscription_type="new"/>
     <rtconnect from="HrpsysJointTrajectoryBridge0.rtc:SequencePlayerService" to="seq.rtc:SequencePlayerService" subscription_type="new"/>
     <rtconnect from="DataLoggerServiceROSBridge.rtc:DataLoggerService" to="log.rtc:DataLoggerService" subscription_type="new"/>
@@ -127,7 +131,7 @@
     <node pkg="hrpsys_ros_bridge" name="RobotHardwareServiceROSBridge" type="RobotHardwareServiceROSBridgeComp"
           output="screen" args ="$(arg openrtm_args)" />
     <rtconnect from="RobotHardwareServiceROSBridge.rtc:RobotHardwareService" to="$(arg SIMULATOR_NAME).rtc:RobotHardwareService"  subscription_type="new"/>
-    <rtconnect from="$(arg SIMULATOR_NAME).rtc:servoState" to="HrpsysSeqStateROSBridge0.rtc:servoState" subscription_type="$(arg subscription_type)" unless="$(arg USE_SOFTERRORLIMIT)"/>
+    <rtconnect from="$(arg SIMULATOR_NAME).rtc:servoState" to="HrpsysSeqStateROSBridge0.rtc:servoState" subscription_type="$(arg subscription_type)" push_policy="$(arg push_policy)" push_rate="$(arg push_rate)" unless="$(arg USE_SOFTERRORLIMIT)"/>
     <rtactivate component="RobotHardwareServiceROSBridge.rtc" />
   </group>
 
@@ -142,18 +146,18 @@
           output="screen" args ="$(arg openrtm_args)" />
     <node pkg="hrpsys_ros_bridge" name="KalmanFilterServiceROSBridge" type="KalmanFilterServiceROSBridgeComp"
           output="screen" args ="$(arg openrtm_args)" />
-    <rtconnect from="abc.rtc:baseTformOut" to="HrpsysSeqStateROSBridge0.rtc:baseTform" subscription_type="$(arg subscription_type)"/>
-    <rtconnect from="abc.rtc:contactStates" to="HrpsysSeqStateROSBridge0.rtc:refContactStates" subscription_type="$(arg subscription_type)"/>
-    <rtconnect from="abc.rtc:controlSwingSupportTime" to="HrpsysSeqStateROSBridge0.rtc:controlSwingSupportTime" subscription_type="$(arg subscription_type)"/>
-    <rtconnect from="kf.rtc:rpy" to="HrpsysSeqStateROSBridge0.rtc:baseRpy" subscription_type="$(arg subscription_type)"/>
-    <rtconnect from="st.rtc:zmp" to="HrpsysSeqStateROSBridge0.rtc:rszmp" subscription_type="$(arg subscription_type)"/>
-    <rtconnect from="st.rtc:refCapturePoint" to="HrpsysSeqStateROSBridge0.rtc:rsrefCapturePoint" subscription_type="$(arg subscription_type)"/>
-    <rtconnect from="st.rtc:actCapturePoint" to="HrpsysSeqStateROSBridge0.rtc:rsactCapturePoint" subscription_type="$(arg subscription_type)"/>
-    <rtconnect from="st.rtc:actContactStates" to="HrpsysSeqStateROSBridge0.rtc:actContactStates" subscription_type="$(arg subscription_type)"/>
+    <rtconnect from="abc.rtc:baseTformOut" to="HrpsysSeqStateROSBridge0.rtc:baseTform" subscription_type="$(arg subscription_type)" push_policy="$(arg push_policy)" push_rate="$(arg push_rate)"/>
+    <rtconnect from="abc.rtc:contactStates" to="HrpsysSeqStateROSBridge0.rtc:refContactStates" subscription_type="$(arg subscription_type)" push_policy="$(arg push_policy)" push_rate="$(arg push_rate)"/>
+    <rtconnect from="abc.rtc:controlSwingSupportTime" to="HrpsysSeqStateROSBridge0.rtc:controlSwingSupportTime" subscription_type="$(arg subscription_type)" push_policy="$(arg push_policy)" push_rate="$(arg push_rate)"/>
+    <rtconnect from="kf.rtc:rpy" to="HrpsysSeqStateROSBridge0.rtc:baseRpy" subscription_type="$(arg subscription_type)" push_policy="$(arg push_policy)" push_rate="$(arg push_rate)"/>
+    <rtconnect from="st.rtc:zmp" to="HrpsysSeqStateROSBridge0.rtc:rszmp" subscription_type="$(arg subscription_type)" push_policy="$(arg push_policy)" push_rate="$(arg push_rate)"/>
+    <rtconnect from="st.rtc:refCapturePoint" to="HrpsysSeqStateROSBridge0.rtc:rsrefCapturePoint" subscription_type="$(arg subscription_type)" push_policy="$(arg push_policy)" push_rate="$(arg push_rate)"/>
+    <rtconnect from="st.rtc:actCapturePoint" to="HrpsysSeqStateROSBridge0.rtc:rsactCapturePoint" subscription_type="$(arg subscription_type)" push_policy="$(arg push_policy)" push_rate="$(arg push_rate)"/>
+    <rtconnect from="st.rtc:actContactStates" to="HrpsysSeqStateROSBridge0.rtc:actContactStates" subscription_type="$(arg subscription_type)" push_policy="$(arg push_policy)" push_rate="$(arg push_rate)"/>
     <rtconnect from="AutoBalancerServiceROSBridge.rtc:AutoBalancerService" to="abc.rtc:AutoBalancerService"  subscription_type="new"/>
     <rtconnect from="StabilizerServiceROSBridge.rtc:StabilizerService" to="st.rtc:StabilizerService"  subscription_type="new"/>
     <rtconnect from="KalmanFilterServiceROSBridge.rtc:KalmanFilterService" to="kf.rtc:KalmanFilterService"  subscription_type="new"/>
-    <rtconnect from="st.rtc:COPInfo" to="HrpsysSeqStateROSBridge0.rtc:rsCOPInfo" subscription_type="$(arg subscription_type)"/>
+    <rtconnect from="st.rtc:COPInfo" to="HrpsysSeqStateROSBridge0.rtc:rsCOPInfo" subscription_type="$(arg subscription_type)" push_policy="$(arg push_policy)" push_rate="$(arg push_rate)"/>
     <rtactivate component="AutoBalancerServiceROSBridge.rtc" />
     <rtactivate component="StabilizerServiceROSBridge.rtc" />
     <rtactivate component="KalmanFilterServiceROSBridge.rtc" />
@@ -222,7 +226,7 @@
        TorqueFilter
   -->
   <group if="$(arg USE_TORQUEFILTER)" >
-    <rtconnect from="tf.rtc:tauOut" to="HrpsysSeqStateROSBridge0.rtc:rstorque" subscription_type="$(arg subscription_type)"/>
+    <rtconnect from="tf.rtc:tauOut" to="HrpsysSeqStateROSBridge0.rtc:rstorque" subscription_type="$(arg subscription_type)" push_policy="$(arg push_policy)" push_rate="$(arg push_rate)"/>
   </group>
   
   <!-- USE_SOFTERRORLIMIT
@@ -232,7 +236,7 @@
     <node pkg="hrpsys_ros_bridge" name="SoftErrorLimiterServiceROSBridge" type="SoftErrorLimiterServiceROSBridgeComp"
           output="screen" args ="$(arg openrtm_args)" />
     <rtconnect from="SoftErrorLimiterServiceROSBridge.rtc:SoftErrorLimiterService" to="el.rtc:SoftErrorLimiterService"  subscription_type="new"/>
-    <rtconnect from="el.rtc:servoStateOut" to="HrpsysSeqStateROSBridge0.rtc:servoState" subscription_type="$(arg subscription_type)"/>
+    <rtconnect from="el.rtc:servoStateOut" to="HrpsysSeqStateROSBridge0.rtc:servoState" subscription_type="$(arg subscription_type)" push_policy="$(arg push_policy)" push_rate="$(arg push_rate)"/>
     <rtactivate component="SoftErrorLimiterServiceROSBridge.rtc" />
   </group>
 
@@ -244,7 +248,7 @@
           output="screen" args ="$(arg openrtm_args)" />
     <node pkg="hrpsys_ros_bridge" name="HardEmergencyStopperServiceROSBridge" type="EmergencyStopperServiceROSBridgeComp"
           output="screen" args ="$(arg openrtm_args)" />
-    <rtconnect from="es.rtc:emergencyMode" to="HrpsysSeqStateROSBridge0.rtc:emergencyMode" subscription_type="$(arg subscription_type)"/>
+    <rtconnect from="es.rtc:emergencyMode" to="HrpsysSeqStateROSBridge0.rtc:emergencyMode" subscription_type="$(arg subscription_type)" push_policy="$(arg push_policy)" push_rate="$(arg push_rate)"/>
     <rtconnect from="EmergencyStopperServiceROSBridge.rtc:EmergencyStopperService" to="es.rtc:EmergencyStopperService"  subscription_type="new"/>
     <rtconnect from="HardEmergencyStopperServiceROSBridge.rtc:EmergencyStopperService" to="hes.rtc:EmergencyStopperService"  subscription_type="new"/>
     <rtactivate component="EmergencyStopperServiceROSBridge.rtc" />

--- a/hrpsys_ros_bridge/launch/hrpsys_ros_bridge.launch
+++ b/hrpsys_ros_bridge/launch/hrpsys_ros_bridge.launch
@@ -40,6 +40,7 @@
   <env name="RTCTREE_NAMESERVERS" value="$(arg nameserver):$(arg corbaport)" />
   <arg name="omniorb_args" default="-ORBInitRef NameService=corbaloc:iiop:$(arg nameserver):$(arg corbaport)/NameService" />
   <arg name="openrtm_args" default='-o "corba.nameservers:$(arg nameserver):$(arg corbaport)" -o "naming.formats:%n.rtc" -o "exec_cxt.periodic.type:PeriodicExecutionContext" -o "exec_cxt.periodic.rate:$(arg periodic_rate)" -o "logger.file_name:/tmp/rtc%p.log"' />
+  <arg name="subscription_type" default="new" />
   <!-- END:openrtm setting -->
   <arg name="OUTPUT" default="screen"/>
   <env name="LANG" value="C" />
@@ -74,12 +75,13 @@
         if="$(arg USE_HRPSYS_PROFILE)"/>
 
   <node pkg="hrpsys_ros_bridge" name="sensor_ros_bridge_connect" type="sensor_ros_bridge_connect.py"
-        args="$(arg MODEL_FILE) $(arg SIMULATOR_NAME) HrpsysSeqStateROSBridge0 $(arg nameserver) $(arg omniorb_args)" output="$(arg OUTPUT)"/>
+        args="$(arg MODEL_FILE) $(arg SIMULATOR_NAME) HrpsysSeqStateROSBridge0 $(arg nameserver) $(arg subscription_type) $(arg omniorb_args)" output="$(arg OUTPUT)"/>
   <!-- BEGIN:openrtm connection -->
   <env name="SIMULATOR_NAME" value="$(arg SIMULATOR_NAME)" />
   <env name="SIMULATOR_NAME_ANGLE"    value="$(arg SIMULATOR_NAME_ANGLE)" />
   <env name="SIMULATOR_NAME_VELOCITY" value="$(arg SIMULATOR_NAME_VELOCITY)" />
   <env name="SIMULATOR_NAME_TORQUE"   value="$(arg SIMULATOR_NAME_TORQUE)" />
+  <env name="subscription_type" value="$(arg subscription_type)" />
   <node name="rtmlaunch_hrpsys_ros_bridge" pkg="openrtm_tools" type="rtmlaunch.py" args="$(find hrpsys_ros_bridge)/launch/hrpsys_ros_bridge.launch USE_COMMON=$(arg USE_COMMON) USE_WALKING=$(arg USE_WALKING) USE_COLLISIONCHECK=$(arg USE_COLLISIONCHECK) USE_IMPEDANCECONTROLLER=$(arg USE_IMPEDANCECONTROLLER) USE_SOFTERRORLIMIT=$(arg USE_SOFTERRORLIMIT) USE_IMAGESENSOR=$(arg USE_IMAGESENSOR) USE_ROBOTHARDWARE=$(arg USE_ROBOTHARDWARE) USE_GRASPCONTROLLER=$(arg USE_GRASPCONTROLLER) USE_SERVOCONTROLLER=$(arg USE_SERVOCONTROLLER) USE_TORQUECONTROLLER=$(arg USE_TORQUECONTROLLER) USE_TORQUEFILTER=$(arg USE_TORQUEFILTER) USE_EMERGENCYSTOPPER=$(arg USE_EMERGENCYSTOPPER) USE_VELOCITY_OUTPUT=$(arg USE_VELOCITY_OUTPUT)" output="$(arg OUTPUT)"/>
 
 
@@ -101,12 +103,12 @@
     <node pkg="hrpsys_ros_bridge" name="StateHolderServiceROSBridge" type="StateHolderServiceROSBridgeComp"
           output="screen" args ="$(arg openrtm_args)" />
 
-    <rtconnect from="$(arg SIMULATOR_NAME_ANGLE).rtc:q"     to="HrpsysSeqStateROSBridge0.rtc:rsangle" subscription_type="new"/>
-    <rtconnect from="$(arg SIMULATOR_NAME_VELOCITY).rtc:dq" to="HrpsysSeqStateROSBridge0.rtc:rsvel" subscription_type="new" if="$(arg USE_VELOCITY_OUTPUT)" />
-    <rtconnect from="$(arg SIMULATOR_NAME_TORQUE).rtc:tau"  to="HrpsysSeqStateROSBridge0.rtc:rstorque" subscription_type="new" unless="$(arg USE_TORQUEFILTER)"/>
+    <rtconnect from="$(arg SIMULATOR_NAME_ANGLE).rtc:q"     to="HrpsysSeqStateROSBridge0.rtc:rsangle" subscription_type="$(arg subscription_type)"/>
+    <rtconnect from="$(arg SIMULATOR_NAME_VELOCITY).rtc:dq" to="HrpsysSeqStateROSBridge0.rtc:rsvel" subscription_type="$(arg subscription_type)" if="$(arg USE_VELOCITY_OUTPUT)" />
+    <rtconnect from="$(arg SIMULATOR_NAME_TORQUE).rtc:tau"  to="HrpsysSeqStateROSBridge0.rtc:rstorque" subscription_type="$(arg subscription_type)" unless="$(arg USE_TORQUEFILTER)"/>
     <rtconnect from="StateHolderServiceROSBridge.rtc:StateHolderService" to="sh.rtc:StateHolderService"  subscription_type="new"/>
-    <rtconnect from="sh.rtc:baseTformOut" to="HrpsysSeqStateROSBridge0.rtc:baseTform" subscription_type="new" unless="$(arg USE_WALKING)"/>
-    <rtconnect from="sh.rtc:qOut" to="HrpsysSeqStateROSBridge0.rtc:mcangle" subscription_type="new"/>
+    <rtconnect from="sh.rtc:baseTformOut" to="HrpsysSeqStateROSBridge0.rtc:baseTform" subscription_type="$(arg subscription_type)" unless="$(arg USE_WALKING)"/>
+    <rtconnect from="sh.rtc:qOut" to="HrpsysSeqStateROSBridge0.rtc:mcangle" subscription_type="$(arg subscription_type)"/>
     <rtconnect from="HrpsysSeqStateROSBridge0.rtc:SequencePlayerService" to="seq.rtc:SequencePlayerService" subscription_type="new"/>
     <rtconnect from="HrpsysJointTrajectoryBridge0.rtc:SequencePlayerService" to="seq.rtc:SequencePlayerService" subscription_type="new"/>
     <rtconnect from="DataLoggerServiceROSBridge.rtc:DataLoggerService" to="log.rtc:DataLoggerService" subscription_type="new"/>
@@ -125,7 +127,7 @@
     <node pkg="hrpsys_ros_bridge" name="RobotHardwareServiceROSBridge" type="RobotHardwareServiceROSBridgeComp"
           output="screen" args ="$(arg openrtm_args)" />
     <rtconnect from="RobotHardwareServiceROSBridge.rtc:RobotHardwareService" to="$(arg SIMULATOR_NAME).rtc:RobotHardwareService"  subscription_type="new"/>
-    <rtconnect from="$(arg SIMULATOR_NAME).rtc:servoState" to="HrpsysSeqStateROSBridge0.rtc:servoState" subscription_type="new" unless="$(arg USE_SOFTERRORLIMIT)"/>
+    <rtconnect from="$(arg SIMULATOR_NAME).rtc:servoState" to="HrpsysSeqStateROSBridge0.rtc:servoState" subscription_type="$(arg subscription_type)" unless="$(arg USE_SOFTERRORLIMIT)"/>
     <rtactivate component="RobotHardwareServiceROSBridge.rtc" />
   </group>
 
@@ -140,18 +142,18 @@
           output="screen" args ="$(arg openrtm_args)" />
     <node pkg="hrpsys_ros_bridge" name="KalmanFilterServiceROSBridge" type="KalmanFilterServiceROSBridgeComp"
           output="screen" args ="$(arg openrtm_args)" />
-    <rtconnect from="abc.rtc:baseTformOut" to="HrpsysSeqStateROSBridge0.rtc:baseTform" subscription_type="new"/>
-    <rtconnect from="abc.rtc:contactStates" to="HrpsysSeqStateROSBridge0.rtc:refContactStates" subscription_type="new"/>
-    <rtconnect from="abc.rtc:controlSwingSupportTime" to="HrpsysSeqStateROSBridge0.rtc:controlSwingSupportTime" subscription_type="new"/>
-    <rtconnect from="kf.rtc:rpy" to="HrpsysSeqStateROSBridge0.rtc:baseRpy" subscription_type="new"/>
-    <rtconnect from="st.rtc:zmp" to="HrpsysSeqStateROSBridge0.rtc:rszmp" subscription_type="new"/>
-    <rtconnect from="st.rtc:refCapturePoint" to="HrpsysSeqStateROSBridge0.rtc:rsrefCapturePoint" subscription_type="new"/>
-    <rtconnect from="st.rtc:actCapturePoint" to="HrpsysSeqStateROSBridge0.rtc:rsactCapturePoint" subscription_type="new"/>
-    <rtconnect from="st.rtc:actContactStates" to="HrpsysSeqStateROSBridge0.rtc:actContactStates" subscription_type="new"/>
+    <rtconnect from="abc.rtc:baseTformOut" to="HrpsysSeqStateROSBridge0.rtc:baseTform" subscription_type="$(arg subscription_type)"/>
+    <rtconnect from="abc.rtc:contactStates" to="HrpsysSeqStateROSBridge0.rtc:refContactStates" subscription_type="$(arg subscription_type)"/>
+    <rtconnect from="abc.rtc:controlSwingSupportTime" to="HrpsysSeqStateROSBridge0.rtc:controlSwingSupportTime" subscription_type="$(arg subscription_type)"/>
+    <rtconnect from="kf.rtc:rpy" to="HrpsysSeqStateROSBridge0.rtc:baseRpy" subscription_type="$(arg subscription_type)"/>
+    <rtconnect from="st.rtc:zmp" to="HrpsysSeqStateROSBridge0.rtc:rszmp" subscription_type="$(arg subscription_type)"/>
+    <rtconnect from="st.rtc:refCapturePoint" to="HrpsysSeqStateROSBridge0.rtc:rsrefCapturePoint" subscription_type="$(arg subscription_type)"/>
+    <rtconnect from="st.rtc:actCapturePoint" to="HrpsysSeqStateROSBridge0.rtc:rsactCapturePoint" subscription_type="$(arg subscription_type)"/>
+    <rtconnect from="st.rtc:actContactStates" to="HrpsysSeqStateROSBridge0.rtc:actContactStates" subscription_type="$(arg subscription_type)"/>
     <rtconnect from="AutoBalancerServiceROSBridge.rtc:AutoBalancerService" to="abc.rtc:AutoBalancerService"  subscription_type="new"/>
     <rtconnect from="StabilizerServiceROSBridge.rtc:StabilizerService" to="st.rtc:StabilizerService"  subscription_type="new"/>
     <rtconnect from="KalmanFilterServiceROSBridge.rtc:KalmanFilterService" to="kf.rtc:KalmanFilterService"  subscription_type="new"/>
-    <rtconnect from="st.rtc:COPInfo" to="HrpsysSeqStateROSBridge0.rtc:rsCOPInfo" subscription_type="new"/>
+    <rtconnect from="st.rtc:COPInfo" to="HrpsysSeqStateROSBridge0.rtc:rsCOPInfo" subscription_type="$(arg subscription_type)"/>
     <rtactivate component="AutoBalancerServiceROSBridge.rtc" />
     <rtactivate component="StabilizerServiceROSBridge.rtc" />
     <rtactivate component="KalmanFilterServiceROSBridge.rtc" />
@@ -220,7 +222,7 @@
        TorqueFilter
   -->
   <group if="$(arg USE_TORQUEFILTER)" >
-    <rtconnect from="tf.rtc:tauOut" to="HrpsysSeqStateROSBridge0.rtc:rstorque" subscription_type="new"/>
+    <rtconnect from="tf.rtc:tauOut" to="HrpsysSeqStateROSBridge0.rtc:rstorque" subscription_type="$(arg subscription_type)"/>
   </group>
   
   <!-- USE_SOFTERRORLIMIT
@@ -230,7 +232,7 @@
     <node pkg="hrpsys_ros_bridge" name="SoftErrorLimiterServiceROSBridge" type="SoftErrorLimiterServiceROSBridgeComp"
           output="screen" args ="$(arg openrtm_args)" />
     <rtconnect from="SoftErrorLimiterServiceROSBridge.rtc:SoftErrorLimiterService" to="el.rtc:SoftErrorLimiterService"  subscription_type="new"/>
-    <rtconnect from="el.rtc:servoStateOut" to="HrpsysSeqStateROSBridge0.rtc:servoState" subscription_type="new"/>
+    <rtconnect from="el.rtc:servoStateOut" to="HrpsysSeqStateROSBridge0.rtc:servoState" subscription_type="$(arg subscription_type)"/>
     <rtactivate component="SoftErrorLimiterServiceROSBridge.rtc" />
   </group>
 
@@ -242,7 +244,7 @@
           output="screen" args ="$(arg openrtm_args)" />
     <node pkg="hrpsys_ros_bridge" name="HardEmergencyStopperServiceROSBridge" type="EmergencyStopperServiceROSBridgeComp"
           output="screen" args ="$(arg openrtm_args)" />
-    <rtconnect from="es.rtc:emergencyMode" to="HrpsysSeqStateROSBridge0.rtc:emergencyMode" subscription_type="new"/>
+    <rtconnect from="es.rtc:emergencyMode" to="HrpsysSeqStateROSBridge0.rtc:emergencyMode" subscription_type="$(arg subscription_type)"/>
     <rtconnect from="EmergencyStopperServiceROSBridge.rtc:EmergencyStopperService" to="es.rtc:EmergencyStopperService"  subscription_type="new"/>
     <rtconnect from="HardEmergencyStopperServiceROSBridge.rtc:EmergencyStopperService" to="hes.rtc:EmergencyStopperService"  subscription_type="new"/>
     <rtactivate component="EmergencyStopperServiceROSBridge.rtc" />

--- a/hrpsys_ros_bridge/scripts/sensor_ros_bridge_connect.py
+++ b/hrpsys_ros_bridge/scripts/sensor_ros_bridge_connect.py
@@ -15,28 +15,28 @@ import OpenHRP
 
 program_name = '[sensor_ros_bridge_connect.py] '
 
-def connecSensorRosBridgePort(url, rh, bridge, vs, rmfo, sh):
+def connecSensorRosBridgePort(url, rh, bridge, vs, rmfo, sh, subscription_type = "new", push_rate = 50.0):
     for sen in hcf.getSensors(url):
         if sen.type in ['Acceleration', 'RateGyro', 'Force']:
             if rh.port(sen.name) != None: # check existence of sensor ;; currently original HRP4C.xml has different naming rule of gsensor and gyrometer
                 print program_name, "connect ", sen.name, rh.port(sen.name).get_port_profile().name, bridge.port(sen.name).get_port_profile().name
-                connectPorts(rh.port(sen.name), bridge.port(sen.name), "new")
+                connectPorts(rh.port(sen.name), bridge.port(sen.name), subscription_type, rate=push_rate)
                 if sen.type == 'Force' and rmfo != None:
                     print program_name, "connect ", sen.name, rmfo.port("off_" + sen.name).get_port_profile().name, bridge.port("off_" + sen.name).get_port_profile().name
-                    connectPorts(rmfo.port("off_" + sen.name), bridge.port("off_" + sen.name), "new") # for abs forces
+                    connectPorts(rmfo.port("off_" + sen.name), bridge.port("off_" + sen.name), subscription_type, rate=push_rate) # for abs forces
                 if sen.type == 'Force' and sh.port(sen.name+"Out") and bridge.port("ref_" + sen.name):
                     print program_name, "connect ", sen.name, sh.port(sen.name+"Out").get_port_profile().name, bridge.port("ref_" + sen.name).get_port_profile().name
-                    connectPorts(sh.port(sen.name+"Out"), bridge.port("ref_" + sen.name), "new") # for reference forces
+                    connectPorts(sh.port(sen.name+"Out"), bridge.port("ref_" + sen.name), subscription_type, rate=push_rate) # for reference forces
         else:
             continue
     if vs != None:
         for vfp in filter(lambda x : str.find(x, 'v') >= 0 and str.find(x, 'sensor') >= 0, vs.ports.keys()):
             print program_name, "connect ", vfp, vs.port(vfp).get_port_profile().name, bridge.port(vfp).get_port_profile().name
-            connectPorts(vs.port(vfp), bridge.port(vfp), "new")
+            connectPorts(vs.port(vfp), bridge.port(vfp), subscription_type, rate=push_rate)
             print program_name, "connect ", vfp, sh.port(vfp+"Out").get_port_profile().name, bridge.port("ref_"+vfp).get_port_profile().name
-            connectPorts(sh.port(vfp+"Out"), bridge.port("ref_" + vfp), "new") # for reference forces
+            connectPorts(sh.port(vfp+"Out"), bridge.port("ref_" + vfp), subscription_type, rate=push_rate) # for reference forces
 
-def initSensorRosBridgeConnection(url, simulator_name, rosbridge_name, managerhost):
+def initSensorRosBridgeConnection(url, simulator_name, rosbridge_name, managerhost, subscription_type):
     hcf.waitForModelLoader()
     hcf.waitForRTCManagerAndRoboHardware(simulator_name, managerhost)
     bridge = rtm.findRTC(rosbridge_name)
@@ -51,13 +51,13 @@ def initSensorRosBridgeConnection(url, simulator_name, rosbridge_name, managerho
         print program_name, " wait for 'sh' : ",sh
     vs=rtm.findRTC('vs')
     rmfo=rtm.findRTC('rmfo')
-    connecSensorRosBridgePort(url, hcf.rh, bridge, vs, rmfo, sh)
+    connecSensorRosBridgePort(url, hcf.rh, bridge, vs, rmfo, sh, subscription_type)
 
 if __name__ == '__main__':
     print program_name, "start"
     hcf=HrpsysConfigurator(program_name)
     if len(sys.argv) > 3 :
-        initSensorRosBridgeConnection(sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4])
+        initSensorRosBridgeConnection(sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4], sys.argv[5])
     else :
         print program_name, " requires url, simulator_name, rosbridge_name"
 

--- a/hrpsys_ros_bridge/scripts/sensor_ros_bridge_connect.py
+++ b/hrpsys_ros_bridge/scripts/sensor_ros_bridge_connect.py
@@ -15,28 +15,28 @@ import OpenHRP
 
 program_name = '[sensor_ros_bridge_connect.py] '
 
-def connecSensorRosBridgePort(url, rh, bridge, vs, rmfo, sh, subscription_type = "new", push_rate = 50.0):
+def connecSensorRosBridgePort(url, rh, bridge, vs, rmfo, sh, subscription_type = "new", push_policy = 'all', push_rate = 50.0):
     for sen in hcf.getSensors(url):
         if sen.type in ['Acceleration', 'RateGyro', 'Force']:
             if rh.port(sen.name) != None: # check existence of sensor ;; currently original HRP4C.xml has different naming rule of gsensor and gyrometer
                 print program_name, "connect ", sen.name, rh.port(sen.name).get_port_profile().name, bridge.port(sen.name).get_port_profile().name
-                connectPorts(rh.port(sen.name), bridge.port(sen.name), subscription_type, rate=push_rate)
+                connectPorts(rh.port(sen.name), bridge.port(sen.name), subscription_type, rate=push_rate, pushpolicy=push_policy)
                 if sen.type == 'Force' and rmfo != None:
                     print program_name, "connect ", sen.name, rmfo.port("off_" + sen.name).get_port_profile().name, bridge.port("off_" + sen.name).get_port_profile().name
-                    connectPorts(rmfo.port("off_" + sen.name), bridge.port("off_" + sen.name), subscription_type, rate=push_rate) # for abs forces
+                    connectPorts(rmfo.port("off_" + sen.name), bridge.port("off_" + sen.name), subscription_type, rate=push_rate, pushpolicy=push_policy) # for abs forces
                 if sen.type == 'Force' and sh.port(sen.name+"Out") and bridge.port("ref_" + sen.name):
                     print program_name, "connect ", sen.name, sh.port(sen.name+"Out").get_port_profile().name, bridge.port("ref_" + sen.name).get_port_profile().name
-                    connectPorts(sh.port(sen.name+"Out"), bridge.port("ref_" + sen.name), subscription_type, rate=push_rate) # for reference forces
+                    connectPorts(sh.port(sen.name+"Out"), bridge.port("ref_" + sen.name), subscription_type, rate=push_rate, pushpolicy=push_policy) # for reference forces
         else:
             continue
     if vs != None:
         for vfp in filter(lambda x : str.find(x, 'v') >= 0 and str.find(x, 'sensor') >= 0, vs.ports.keys()):
             print program_name, "connect ", vfp, vs.port(vfp).get_port_profile().name, bridge.port(vfp).get_port_profile().name
-            connectPorts(vs.port(vfp), bridge.port(vfp), subscription_type, rate=push_rate)
+            connectPorts(vs.port(vfp), bridge.port(vfp), subscription_type, rate=push_rate, pushpolicy=push_policy)
             print program_name, "connect ", vfp, sh.port(vfp+"Out").get_port_profile().name, bridge.port("ref_"+vfp).get_port_profile().name
-            connectPorts(sh.port(vfp+"Out"), bridge.port("ref_" + vfp), subscription_type, rate=push_rate) # for reference forces
+            connectPorts(sh.port(vfp+"Out"), bridge.port("ref_" + vfp), subscription_type, rate=push_rate, pushpolicy=push_policy) # for reference forces
 
-def initSensorRosBridgeConnection(url, simulator_name, rosbridge_name, managerhost, subscription_type):
+def initSensorRosBridgeConnection(url, simulator_name, rosbridge_name, managerhost, subscription_type, push_policy, push_rate):
     hcf.waitForModelLoader()
     hcf.waitForRTCManagerAndRoboHardware(simulator_name, managerhost)
     bridge = rtm.findRTC(rosbridge_name)
@@ -51,13 +51,13 @@ def initSensorRosBridgeConnection(url, simulator_name, rosbridge_name, managerho
         print program_name, " wait for 'sh' : ",sh
     vs=rtm.findRTC('vs')
     rmfo=rtm.findRTC('rmfo')
-    connecSensorRosBridgePort(url, hcf.rh, bridge, vs, rmfo, sh, subscription_type)
+    connecSensorRosBridgePort(url, hcf.rh, bridge, vs, rmfo, sh, subscription_type, push_policy, push_rate)
 
 if __name__ == '__main__':
     print program_name, "start"
     hcf=HrpsysConfigurator(program_name)
     if len(sys.argv) > 3 :
-        initSensorRosBridgeConnection(sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4], sys.argv[5])
+        initSensorRosBridgeConnection(sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4], sys.argv[5], sys.argv[6], sys.argv[7])
     else :
         print program_name, " requires url, simulator_name, rosbridge_name"
 

--- a/openrtm_tools/src/openrtm_tools/rtmlaunch.py
+++ b/openrtm_tools/src/openrtm_tools/rtmlaunch.py
@@ -110,12 +110,16 @@ def rtconnect(nameserver, tags, tree):
         try:
             sub_type = str(sub_type)
             props = {'dataport.subscription_type': sub_type}
+            if tag.attributes.get("push_policy") != None:
+                push_policy = replace_arg_tag_by_env(str(tag.attributes.get("push_policy").value));
+            else:
+                push_policy = 'all'
             if sub_type == 'new':
-                props['dataport.publisher.push_policy'] = 'all'
+                props['dataport.publisher.push_policy'] = push_policy
             elif sub_type == 'periodic':
-                props['dataport.publisher.push_policy'] = 'all'
+                props['dataport.publisher.push_policy'] = push_policy
                 if tag.attributes.get("push_rate") != None:
-                    props['dataport.push_rate'] = str(tag.attributes.get("push_rate").value)
+                    props['dataport.push_rate'] = replace_arg_tag_by_env(str(tag.attributes.get("push_rate").value))
                 else:
                     props['dataport.push_rate'] = str('50.0')
             options = optparse.Values({'verbose': False, 'id': '', 'name': None, 'properties': props})

--- a/openrtm_tools/src/openrtm_tools/rtmlaunch.py
+++ b/openrtm_tools/src/openrtm_tools/rtmlaunch.py
@@ -89,6 +89,7 @@ def rtconnect(nameserver, tags, tree):
         dest_full_path = path.cmd_path_to_full_path(dest_path)
         if tag.attributes.get("subscription_type") != None:
             sub_type = tag.attributes.get("subscription_type").value
+            sub_type = replace_arg_tag_by_env(sub_type);
             if not sub_type in ['flush','new','periodic']:
                 print >>sys.stderr, sub_type+' is not a subscription type'
                 continue


### PR DESCRIPTION
Enable to set subscription type, push_policy, and push_rate.
Currently, DataPorts connection settings are written in hrpsys_ros_bridge.launch and sensor_rso_bridge_connect.py.
After this PR, we can change subscription_type, push_policy, and push_rate from arguments of hrpsys_ros_bridge.launch
Use "new", "all", and "50.0" respectively to keep backward compatibility.