### PR TITLE
Support ReferenceForceUpdater in hrpsys

### DIFF
--- a/hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l
+++ b/hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l
@@ -1582,6 +1582,24 @@
    )
 )
 
+;; ReferenceForceUpdater
+(def-set-get-param-method
+  'hrpsys_ros_bridge::Openhrp_ReferenceForceUpdaterService_ReferenceForceUpdaterParam
+  :set-reference-force-updater-param :get-reference-force-updater-param
+  :ReferenceForceUpdaterService_setReferenceForceUpdaterParam :ReferenceForceUpdaterService_getReferenceForceUpdaterParam)
+(defmethod rtm-ros-robot-interface
+  (:start-reference-force-updater
+   ()
+   "Start reference force updater."
+   (send self :referenceforceupdaterservice_startReferenceforceupdater)
+   )
+  (:stop-reference-force-updater
+   ()
+   "Stop reference force updater."
+   (send self :referenceforceupdaterservice_stopReferenceforceupdater)
+   )
+  )
+
 (defun print-end-effector-parameter-conf-from-robot
   (rb)
   "Print end effector setting for hrpsys conf file."

--- a/hrpsys_ros_bridge/launch/hrpsys_ros_bridge.launch
+++ b/hrpsys_ros_bridge/launch/hrpsys_ros_bridge.launch
@@ -27,6 +27,7 @@
   <arg name="USE_TORQUEFILTER" default="false" />
   <arg name="USE_IMAGESENSOR" default="false" />
   <arg name="USE_EMERGENCYSTOPPER" default="false" />
+  <arg name="USE_REFERENCEFORCEUPDATER" default="false" />
   <arg name="USE_HRPSYS_PROFILE" default="true" />
   <arg name="USE_VELOCITY_OUTPUT" default="false" />
   <arg name="PUBLISH_SENSOR_TF" default="true" />
@@ -86,7 +87,7 @@
   <env name="subscription_type" value="$(arg subscription_type)" />
   <env name="push_policy" value="$(arg push_policy)" />
   <env name="push_rate" value="$(arg push_rate)" />
-  <node name="rtmlaunch_hrpsys_ros_bridge" pkg="openrtm_tools" type="rtmlaunch.py" args="$(find hrpsys_ros_bridge)/launch/hrpsys_ros_bridge.launch USE_COMMON=$(arg USE_COMMON) USE_WALKING=$(arg USE_WALKING) USE_COLLISIONCHECK=$(arg USE_COLLISIONCHECK) USE_IMPEDANCECONTROLLER=$(arg USE_IMPEDANCECONTROLLER) USE_SOFTERRORLIMIT=$(arg USE_SOFTERRORLIMIT) USE_IMAGESENSOR=$(arg USE_IMAGESENSOR) USE_ROBOTHARDWARE=$(arg USE_ROBOTHARDWARE) USE_GRASPCONTROLLER=$(arg USE_GRASPCONTROLLER) USE_SERVOCONTROLLER=$(arg USE_SERVOCONTROLLER) USE_TORQUECONTROLLER=$(arg USE_TORQUECONTROLLER) USE_TORQUEFILTER=$(arg USE_TORQUEFILTER) USE_EMERGENCYSTOPPER=$(arg USE_EMERGENCYSTOPPER) USE_VELOCITY_OUTPUT=$(arg USE_VELOCITY_OUTPUT)" output="$(arg OUTPUT)"/>
+  <node name="rtmlaunch_hrpsys_ros_bridge" pkg="openrtm_tools" type="rtmlaunch.py" args="$(find hrpsys_ros_bridge)/launch/hrpsys_ros_bridge.launch USE_COMMON=$(arg USE_COMMON) USE_WALKING=$(arg USE_WALKING) USE_COLLISIONCHECK=$(arg USE_COLLISIONCHECK) USE_IMPEDANCECONTROLLER=$(arg USE_IMPEDANCECONTROLLER) USE_SOFTERRORLIMIT=$(arg USE_SOFTERRORLIMIT) USE_IMAGESENSOR=$(arg USE_IMAGESENSOR) USE_ROBOTHARDWARE=$(arg USE_ROBOTHARDWARE) USE_GRASPCONTROLLER=$(arg USE_GRASPCONTROLLER) USE_SERVOCONTROLLER=$(arg USE_SERVOCONTROLLER) USE_TORQUECONTROLLER=$(arg USE_TORQUECONTROLLER) USE_TORQUEFILTER=$(arg USE_TORQUEFILTER) USE_EMERGENCYSTOPPER=$(arg USE_EMERGENCYSTOPPER) USE_REFERENCEFORCEUPDATER=$(arg USE_REFERENCEFORCEUPDATER) USE_VELOCITY_OUTPUT=$(arg USE_VELOCITY_OUTPUT)" output="$(arg OUTPUT)"/>
 
 
   <!-- All Robots -->
@@ -253,6 +254,13 @@
     <rtconnect from="HardEmergencyStopperServiceROSBridge.rtc:EmergencyStopperService" to="hes.rtc:EmergencyStopperService"  subscription_type="new"/>
     <rtactivate component="EmergencyStopperServiceROSBridge.rtc" />
     <rtactivate component="HardEmergencyStopperServiceROSBridge.rtc" />
+  </group>
+
+  <group if="$(arg USE_REFERENCEFORCEUPDATER)" >
+    <node pkg="hrpsys_ros_bridge" name="ReferenceForceUpdaterServiceROSBridge" type="ReferenceForceUpdaterServiceROSBridgeComp"
+          output="screen" args ="$(arg openrtm_args)" />
+    <rtconnect from="ReferenceForceUpdaterServiceROSBridge.rtc:ReferenceForceUpdaterService" to="rfu.rtc:ReferenceForceUpdaterService"  subscription_type="new"/>
+    <rtactivate component="ReferenceForceUpdaterServiceROSBridge.rtc" />
   </group>
 
   <!-- USER_IMAGESENSOR

--- a/hrpsys_ros_bridge/scripts/default_robot_ros_bridge.launch.in
+++ b/hrpsys_ros_bridge/scripts/default_robot_ros_bridge.launch.in
@@ -15,6 +15,7 @@
     <arg name="USE_WALKING" default="true" if="$(arg USE_UNSTABLE_RTC)"/>
     <arg name="USE_IMPEDANCECONTROLLER" default="true" if="$(arg USE_UNSTABLE_RTC)" />
     <arg name="USE_EMERGENCYSTOPPER" default="true" if="$(arg USE_UNSTABLE_RTC)" />
+    <arg name="USE_REFERENCEFORCEUPDATER" default="true" if="$(arg USE_UNSTABLE_RTC)" />
 @ROSBRIDGE_ARGS@
 
   </include>

--- a/hrpsys_tools/launch/hrpsys.launch
+++ b/hrpsys_tools/launch/hrpsys.launch
@@ -70,6 +70,7 @@
 -o "example.HGcontroller.config_file:$(arg CONF_FILE)"
 -o "example.PDcontroller.config_file:$(arg CONF_FILE)"
 -o "example.EmergencyStopper.config_file:$(arg CONF_FILE)"
+-o "example.ReferenceForceUpdater.config_file:$(arg CONF_FILE)"
 -o "example.RobotHardware.config_file:$(arg RobotHardware_conf)"
     '/>
   <arg name="hrpsys_opt_rtc_config_args" default=''/>


### PR DESCRIPTION
https://github.com/fkanehiro/hrpsys-base/pull/974 がmergeされたら、こちらもマージをお願いいたします。

hrpsysにReferenceForceUpdaterを追加したことに伴い、hrpsys_ros_bridgeから ReferenceForceUpdaterを使えるようにしました。また、roseusからのインターフェースを追加しています。
例えば、以下のように使います。
```
rtmlaunch hrpsys_ros_bridge_tutorials samplerobot.launch
```
(other terminal)
```
roseus `rospack find hrpsys_ros_bridge_tutorials`/euslisp/samplerobot-interface.l
(samplerobot-init)
(send *ri* :start-reference-force-updater) ;;reference-force-updaterがref-forceを更新するようになる。
(send *ri* :get-reference-force-updater-param) ;;パラメータの取得
(send *ri* :stop-reference-force-updater) ;;reference-force-updaterによるref-forceの更新を止める。
```

@snozawa さん