### PR TITLE
HrpsysSeqStateROSBridgeImpl.cpp: sensor->localR is world coords

### DIFF
--- a/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridgeImpl.cpp
+++ b/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridgeImpl.cpp
@@ -178,7 +178,10 @@ RTC::ReturnCode_t HrpsysSeqStateROSBridgeImpl::onInitialize()
           rpy = hrp::rpyFromRot(sensor->localR * m);
         }
       else
-        rpy = hrp::rpyFromRot(sensor->localR);
+      {
+        // localR is parent. https://github.com/start-jsk/rtmros_common/pull/925
+        rpy = hrp::rpyFromRot(sensor->link->Rs.inverse() * sensor->localR);
+      }
       si.transform.setRotation( tf::createQuaternionFromRPY(rpy(0), rpy(1), rpy(2)) );
       OpenHRP::LinkInfoSequence_var links = bodyinfo->links();
       for ( int k = 0; k < links->length(); k++ ) {


### PR DESCRIPTION

nextage/hironxで手先にセンサをつけた時（以下のモデルを使う
https://gist.github.com/k-okada/872470bf55a6c15f8a1abc69aadc7397 
）
にTFの角度がずれるという問題です．

![screenshot from 2016-04-15 00 39 31](https://cloud.githubusercontent.com/assets/493276/14534533/93acaec8-02a4-11e6-8f3d-a879fe79f68b.png)


nextage/hironx の特徴として肩の関節が15どずれているというのがあって，
それそのままセンサのtfに反映されていそうです．

で，

https://github.com/fkanehiro/openhrp3/blob/master/hrplib/hrpModel/ModelLoaderUtil.cpp#L403

で

```
sensor->localR = Rs * R;
```

となっていてlocalRだけど，リンク想定ではなくてベース相対というやつなんかと思っていて，
これってどこかで分かりづらくない？でも昔からこれでやっているから，というような議論があった
気がしますが，そうだと解釈てこのPRをつくりました．



![screenshot from 2016-04-15 00 31 51](https://cloud.githubusercontent.com/assets/493276/14534542/9dd566ba-02a4-11e6-9782-1f29328e4699.png)


どうでしょうか？