### PR TITLE
Revert "workaround for ros-groovy-rqt-top installs wrong(?) psutil"

### DIFF
--- a/openrtm_tools/src/openrtm_tools/rtmstart.py
+++ b/openrtm_tools/src/openrtm_tools/rtmstart.py
@@ -1,8 +1,5 @@
 #!/usr/bin/python
 
-import sys; sys.path.insert(0,"/usr/lib/python{0}.{1}/dist-packages".format(sys.version_info[0],sys.version_info[1])) ## ros-groovy-rqt-top install psutil under /opt/groovy/lib/python.. which is not working...
-
-
 import os,psutil,subprocess,socket,sys
 from omniORB import CORBA
 import CosNaming


### PR DESCRIPTION
This reverts commit 94975a81eadbf251a85b2fd3c77137b1f96f248b. To fix #936 