### PR TITLE
Set /robot/type param according to lower-case robot name such as samplerobot.

### DIFF
--- a/hrpsys_ros_bridge/launch/hrpsys_ros_bridge.launch
+++ b/hrpsys_ros_bridge/launch/hrpsys_ros_bridge.launch
@@ -46,6 +46,8 @@
   <arg name="push_rate" default="50.0" />
   <!-- END:openrtm setting -->
   <arg name="OUTPUT" default="screen"/>
+  <arg name="ROBOT_TYPE" default=""/>
+  <arg name="USE_ROBOT_TYPE_SETTING" default="false"/>
   <env name="LANG" value="C" />
   <env name="ORBgiopMaxMsgSize" value="2147483648" />
 
@@ -282,5 +284,7 @@
            if="$(arg USE_ROBOT_POSE_EKF)">
     <arg name="base_link" value="$(arg BASE_LINK)"/>
   </include>
+
+  <rosparam param="robot/type" subst_value="True" if="$(arg USE_ROBOT_TYPE_SETTING)">$(arg ROBOT_TYPE)</rosparam>
 </launch>
 

--- a/hrpsys_ros_bridge/scripts/default_robot_ros_bridge.launch.in
+++ b/hrpsys_ros_bridge/scripts/default_robot_ros_bridge.launch.in
@@ -16,6 +16,8 @@
     <arg name="USE_IMPEDANCECONTROLLER" default="true" if="$(arg USE_UNSTABLE_RTC)" />
     <arg name="USE_EMERGENCYSTOPPER" default="true" if="$(arg USE_UNSTABLE_RTC)" />
     <arg name="USE_REFERENCEFORCEUPDATER" default="true" if="$(arg USE_UNSTABLE_RTC)" />
+    <arg name="ROBOT_TYPE" default="@robot@" if="$(arg USE_UNSTABLE_RTC)" />
+    <arg name="USE_ROBOT_TYPE_SETTING" default="true" if="$(arg USE_UNSTABLE_RTC)" />
 @ROSBRIDGE_ARGS@
 
   </include>


### PR DESCRIPTION
Set /robot/type param according to lower-case robot name such as `samplerobot`.
Use /robot/type setting only if USE_UNSTABLE_RTC, e.g., default behavior does not change.

https://github.com/jsk-ros-pkg/jsk_robot/pull/398
ros-infrastructure/rep#104
https://github.com/jsk-ros-pkg/jsk_robot/pull/401