### PR TITLE
[euslisp/datalogger-log-parser.l] Modify unit of cogvel [m] -> [mm] for euslisp

### DIFF
--- a/hrpsys_ros_bridge/euslisp/datalogger-log-parser.l
+++ b/hrpsys_ros_bridge/euslisp/datalogger-log-parser.l
@@ -144,9 +144,9 @@
            (mapcar #'(lambda (x) (send robot x :end-coords :copy-worldcoords)) limb-list)))
    ;; Stabilizer parameter
    (let ((rsd (send self :parser-list "st_originRefCogVel")))
-     (if rsd (send self :set-robot-state1 :stabilizer-reference-cogvel (send rsd :read-state))))
+     (if rsd (send self :set-robot-state1 :stabilizer-reference-cogvel (scale 1e3 (send rsd :read-state)))))
    (let ((rsd (send self :parser-list "st_originActCogVel")))
-     (if rsd (send self :set-robot-state1 :stabilizer-cogvel (send rsd :read-state))))
+     (if rsd (send self :set-robot-state1 :stabilizer-cogvel (scale 1e3 (send rsd :read-state)))))
    (let ((rsd (send self :parser-list "st_originRefZmp")))
      (if rsd (send self :set-robot-state1 :stabilizer-reference-zmp (scale 1e3 (send rsd :read-state)))))
    (let ((rsd (send self :parser-list "st_originActZmp")))


### PR DESCRIPTION
https://github.com/jsk-ros-pkg/euslib/pull/152
を受け
dataloggerのcogvelの単位を[m]から[mm]に変更いたしました.
