### PR TITLE
re-enable rosnode_rtc

### DIFF
--- a/openrtm_tools/CMakeLists.txt
+++ b/openrtm_tools/CMakeLists.txt
@@ -50,7 +50,8 @@ catkin_python_setup()
 ## CATKIN_DEPENDS: catkin_packages dependent projects also need
 ## DEPENDS: system dependencies of this project that dependent projects also need
 
-unset(openrtm_aist_LIBRARIES CACHE) # remove not to add openrtm_aist_LIBRARIES to openrtm_toolsConfig.cmake
+find_package(PkgConfig)
+pkg_check_modules(openrtm_aist REQUIRED openrtm-aist)
 catkin_package(
 #  INCLUDE_DIRS include
 #  LIBRARIES openrtm_tools

--- a/rosnode_rtc/CMakeLists.txt
+++ b/rosnode_rtc/CMakeLists.txt
@@ -6,7 +6,6 @@ find_package(catkin REQUIRED COMPONENTS openrtm_tools)
 
 catkin_package()
 
-install(DIRECTORY scripts/
-        DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-        USE_SOURCE_PERMISSIONS
-        PATTERN ".svn" EXCLUDE)
+install(DIRECTORY scripts sample desktop
+        DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+        USE_SOURCE_PERMISSIONS)

--- a/rosnode_rtc/sample/dataport_rtinject.sh
+++ b/rosnode_rtc/sample/dataport_rtinject.sh
@@ -11,7 +11,7 @@ do
 done
 echo "start injecting ${count} times to ${port}"
 
-rosrun rtshell rtinject -p /tmp -m RTMROSDataBridge -n ${count} -c "${data}" ${port}
+rtinject -p /tmp -m RTMROSDataBridge -n ${count} -c "${data}" ${port}
 
 # this script may not work in OpenRTM-Python-1.1.0
 # ModuleMgr.find_class in rtshell does not parse dataport.data_type

--- a/rosnode_rtc/sample/dataport_rtprint.sh
+++ b/rosnode_rtc/sample/dataport_rtprint.sh
@@ -8,4 +8,4 @@ do
     sleep 1
 done
 echo "start listening ${port}"
-rosrun rtshell rtprint -p /tmp -m RTMROSDataBridge ${port}
+rtprint -p /tmp -m RTMROSDataBridge ${port}

--- a/rosnode_rtc/sample/stage_sample_send_goal.sh
+++ b/rosnode_rtc/sample/stage_sample_send_goal.sh
@@ -7,4 +7,4 @@ pos_y=25    # 15,20,25
 port=move_base_simple_goal
 data="RTMROSDataBridge.geometry_msgs_PoseStamped(header=RTMROSDataBridge.std_msgs_Header(seq=0, stamp=RTC.Time(sec=0, nsec=0), frame_id='/map'), pose=RTMROSDataBridge.geometry_msgs_Pose(position=RTMROSDataBridge.geometry_msgs_Point(x=${pos_x}, y=${pos_y}, z=0.0), orientation=RTMROSDataBridge.geometry_msgs_Quaternion(x=0.0, y=0.0, z=0.0, w=1.0)))"
 
-rosrun rtshell rtinject -p /tmp -m RTMROSDataBridge -c "${data}" /localhost/move_base_node0.rtc:${port}
+rtinject -p /tmp -m RTMROSDataBridge -c "${data}" /localhost/move_base_node0.rtc:${port}

--- a/rosnode_rtc/scripts/rtmros-data-bridge.py
+++ b/rosnode_rtc/scripts/rtmros-data-bridge.py
@@ -25,8 +25,8 @@ import genpy
 
 # rtm modules
 import time
-import RTC
 import OpenRTM_aist
+import RTC
 
 module_spec = ["implementation_id", "<implementation_id>",
                "type_name",         "<type_name>",

--- a/rtmbuild/CMakeLists.txt
+++ b/rtmbuild/CMakeLists.txt
@@ -10,7 +10,7 @@ if (!OMNIORB_FOUND)
 endif()
 
 catkin_package(
-  DEPENDS omniorb
+  DEPENDS OMNIORB
   CATKIN_DEPENDS message_generation std_msgs
   CFG_EXTRAS servicebridge.cmake rtmbuild.cmake
   )


### PR DESCRIPTION
- CMakeLists.txt : install scripts/ sample/ desktop/ to CATKIN_PACKAGE_SHARE_DESTINATION
- rosnode_rtc/sample : now rtshell is installed in global bin
- rosnode_rtc/scripts/rtmros-data-bridge.py: import RTC after OpenRTM_aist