### PR TITLE
Separate offset-removed force sensor data ports from rsforce.

### DIFF
--- a/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridgeImpl.cpp
+++ b/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridgeImpl.cpp
@@ -131,25 +131,27 @@ RTC::ReturnCode_t HrpsysSeqStateROSBridgeImpl::onInitialize()
   }
 
   coil::vstring virtual_force_sensor = coil::split(prop["virtual_force_sensor"], ",");
-  int npforce = body->numSensors(hrp::Sensor::FORCE) * 2; // forces + absolute forces
+  int npforce = body->numSensors(hrp::Sensor::FORCE);
   int nvforce = virtual_force_sensor.size()/10;
   int nforce  = npforce + nvforce;
   m_rsforce.resize(nforce);
   m_rsforceIn.resize(nforce);
-  m_mcforce.resize(npforce/2+nvforce);
-  m_mcforceIn.resize(npforce/2+nvforce);
-  for (unsigned int i=0; i<npforce/2; i++){
+  m_offforce.resize(nforce);
+  m_offforceIn.resize(nforce);
+  m_mcforce.resize(npforce+nvforce);
+  m_mcforceIn.resize(npforce+nvforce);
+  for (unsigned int i=0; i<npforce; i++){
     hrp::Sensor *s = body->sensor(hrp::Sensor::FORCE, i);
     // force and moment
-    m_rsforceIn[i*2] = new InPort<TimedDoubleSeq>(s->name.c_str(), m_rsforce[i*2]);
-    m_rsforce[i*2].data.length(6);
-    registerInPort(s->name.c_str(), *m_rsforceIn[i*2]);
+    m_rsforceIn[i] = new InPort<TimedDoubleSeq>(s->name.c_str(), m_rsforce[i]);
+    m_rsforce[i].data.length(6);
+    registerInPort(s->name.c_str(), *m_rsforceIn[i]);
     m_rsforceName.push_back(s->name);
     // off force and moment
-    m_rsforceIn[i*2+1] = new InPort<TimedDoubleSeq>(std::string("off_" + s->name).c_str(), m_rsforce[i*2+1]);
-    m_rsforce[i*2+1].data.length(6);
-    registerInPort(s->name.c_str(), *m_rsforceIn[i*2+1]);
-    m_rsforceName.push_back(std::string("off_" + s->name));
+    m_offforceIn[i] = new InPort<TimedDoubleSeq>(std::string("off_" + s->name).c_str(), m_offforce[i]);
+    m_offforce[i].data.length(6);
+    registerInPort(s->name.c_str(), *m_offforceIn[i]);
+    m_offforceName.push_back(std::string("off_" + s->name));
     // ref force and moment
     m_mcforceIn[i] = new InPort<TimedDoubleSeq>(std::string("ref_" + s->name).c_str(), m_mcforce[i]);
     m_mcforce[i].data.length(6);

--- a/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridgeImpl.h
+++ b/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridgeImpl.h
@@ -106,12 +106,19 @@ class HrpsysSeqStateROSBridgeImpl  : public RTC::DataFlowComponentBase
   InPort<TimedDoubleSeq> m_rsangleIn;
   TimedDoubleSeq m_mcangle;
   InPort<TimedDoubleSeq> m_mcangleIn;
+  // Actual force/moment ports
   std::vector<TimedDoubleSeq> m_rsforce;
   std::vector<InPort<TimedDoubleSeq> *> m_rsforceIn;
   std::vector<std::string> m_rsforceName;
+  // Offset-removed force/moment ports
+  std::vector<TimedDoubleSeq> m_offforce;
+  std::vector<InPort<TimedDoubleSeq> *> m_offforceIn;
+  std::vector<std::string> m_offforceName;
+  // Reference force/moment ports
   std::vector<TimedDoubleSeq> m_mcforce;
   std::vector<InPort<TimedDoubleSeq> *> m_mcforceIn;
   std::vector<std::string> m_mcforceName;
+  // Gyro and acceleration sensors
   std::vector<TimedAcceleration3D> m_gsensor;
   std::vector<InPort<TimedAcceleration3D> *> m_gsensorIn;
   std::vector<std::string> m_gsensorName;


### PR DESCRIPTION
Separate offset-removed force sensor data ports from rsforce, which is actual and non-offset-removed data port.
Previous : rsforce ports (including rsforce and offforce)
Current : rsforce ports + offforce ports (separated)

This PR is expected not to change HrpsysSeqStateROSBridge behavior in terms of published `WrenchStamped` topics.
This PR is also related only with UnstableRTC environments.