### PR TITLE
HrpsysJointTrajectoryBridge.cpp: enable to publish feedback

### DIFF
--- a/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.cpp
+++ b/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.cpp
@@ -427,6 +427,15 @@ RTC::ReturnCode_t HrpsysSeqStateROSBridge::onExecute(RTC::UniqueId ec_id)
         follow_joint_trajectory_feedback.desired.positions.push_back(j->q);
         follow_joint_trajectory_feedback.actual.positions.push_back(j->q);
         follow_joint_trajectory_feedback.error.positions.push_back(0);
+        follow_joint_trajectory_feedback.desired.velocities.push_back(j->dq);
+        follow_joint_trajectory_feedback.actual.velocities.push_back(j->dq);
+        follow_joint_trajectory_feedback.error.velocities.push_back(0);
+        follow_joint_trajectory_feedback.desired.accelerations.push_back(j->ddq);
+        follow_joint_trajectory_feedback.actual.accelerations.push_back(j->ddq);
+        follow_joint_trajectory_feedback.error.accelerations.push_back(0);
+        follow_joint_trajectory_feedback.desired.effort.push_back(j->u);
+        follow_joint_trajectory_feedback.actual.effort.push_back(j->u);
+        follow_joint_trajectory_feedback.error.effort.push_back(0);
       }
       ++it;
     }
@@ -472,6 +481,20 @@ RTC::ReturnCode_t HrpsysSeqStateROSBridge::onExecute(RTC::UniqueId ec_id)
       interpolationp = false;
     }
 
+    ros::Time tm_on_execute = ros::Time::now();
+
+    if ( joint_trajectory_server.isActive() ) {
+      pr2_controllers_msgs::JointTrajectoryFeedback joint_trajectory_feedback;
+      joint_trajectory_server.publishFeedback(joint_trajectory_feedback);
+    }
+    if ( follow_joint_trajectory_server.isActive() ) {
+      follow_joint_trajectory_feedback.header.stamp = tm_on_execute;
+      if (!follow_joint_trajectory_feedback.joint_names.empty() &&
+          !follow_joint_trajectory_feedback.actual.positions.empty())
+      {
+        follow_joint_trajectory_server.publishFeedback(follow_joint_trajectory_feedback);
+      }
+    }
     ros::spinOnce();
 
     // diagnostics


### PR DESCRIPTION
this is currently disabled, https://github.com/start-jsk/rtmros_common/commit/a49042b567b92884062da88f287e2f71c061321e#commitcomment-18894675

not sure why, but one possibility is publishing feedback at high rate may decrease the performance