### PR TITLE
[rtm-ros-robot-interface.l] temporary fix controller action name

### DIFF
--- a/hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l
+++ b/hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l
@@ -41,6 +41,13 @@
                                  #'send self :rtmros-contact-states-callback (read-from-string (format nil ":~A-contact-states" x)) :groupname groupname))
              '(ref act))
      ))
+  (:default-controller ()
+   (list
+    (list
+     (cons :controller-action "fullbody_controller/follow_joint_trajectory_action")
+     (cons :controller-state "fullbody_controller/state")
+     (cons :action-type control_msgs::FollowJointTrajectoryAction)
+     (cons :joint-names (mapcar #'(lambda (n) (if (symbolp n) (symbol-name n) n)) (send-all (send robot :joint-list) :name))))))
   (:rtmros-motor-states-callback
    (msg)
    (send self :set-robot-state1 :motor-extra-data (send msg :extra_data))


### PR DESCRIPTION
relate to https://github.com/jsk-ros-pkg/jsk_pr2eus/pull/237
default joint_trajectory_action method should be changed to follow_joint_trajectory_action.