### PR TITLE
[hrpsys_ros_bridge] fix model filename

### DIFF
--- a/hrpsys_ros_bridge/launch/hrpsys_ros_bridge.launch
+++ b/hrpsys_ros_bridge/launch/hrpsys_ros_bridge.launch
@@ -54,14 +54,14 @@
   <node name = "HrpsysSeqStateROSBridge"
         pkg  = "hrpsys_ros_bridge"
         type = "HrpsysSeqStateROSBridge"
-        args = '$(arg openrtm_args) -o model:$(arg MODEL_FILE) -o example.HrpsysSeqStateROSBridge.config_file:$(arg CONF_FILE)'
+        args = "$(arg openrtm_args) -o model:'file://$(arg MODEL_FILE)' -o example.HrpsysSeqStateROSBridge.config_file:$(arg CONF_FILE)"
         output = "$(arg OUTPUT)">
     <param name="publish_sensor_transforms" value="$(arg PUBLISH_SENSOR_TF)" />
   </node>
   <node name = "HrpsysJointTrajectoryBridge"
         pkg  = "hrpsys_ros_bridge"
         type = "HrpsysJointTrajectoryBridge"
-        args = "$(arg openrtm_args) -o model:$(arg MODEL_FILE)"
+        args = "$(arg openrtm_args) -o model:'file://$(arg MODEL_FILE)'"
         output = "$(arg OUTPUT)" />
 
   <group if="$(arg INSTALL_ROBOT_DESCRIPTION)" >


### PR DESCRIPTION
Enable cache in ModelLoader
filename should be same as in .conf file.