### PR TITLE
If rmfo is available, connect rmfo' force sensor ports instead of rh's force sensor ports. Otherwise, connect rh's force sensor ports.

### DIFF
--- a/hrpsys_ros_bridge/scripts/sensor_ros_bridge_connect.py
+++ b/hrpsys_ros_bridge/scripts/sensor_ros_bridge_connect.py
@@ -19,11 +19,14 @@ def connecSensorRosBridgePort(url, rh, bridge, vs, rmfo, sh, subscription_type =
     for sen in hcf.getSensors(url):
         if sen.type in ['Acceleration', 'RateGyro', 'Force']:
             if rh.port(sen.name) != None: # check existence of sensor ;; currently original HRP4C.xml has different naming rule of gsensor and gyrometer
-                print program_name, "connect ", sen.name, rh.port(sen.name).get_port_profile().name, bridge.port(sen.name).get_port_profile().name
-                connectPorts(rh.port(sen.name), bridge.port(sen.name), subscription_type, rate=push_rate, pushpolicy=push_policy)
+                # If rmfo is available, connect rmfo' force sensor ports instead of rh's force sensor ports.
+                # Otherwise, connect rh's force sensor ports.
                 if sen.type == 'Force' and rmfo != None:
                     print program_name, "connect ", sen.name, rmfo.port("off_" + sen.name).get_port_profile().name, bridge.port("off_" + sen.name).get_port_profile().name
                     connectPorts(rmfo.port("off_" + sen.name), bridge.port("off_" + sen.name), subscription_type, rate=push_rate, pushpolicy=push_policy) # for abs forces
+                else:
+                    print program_name, "connect ", sen.name, rh.port(sen.name).get_port_profile().name, bridge.port(sen.name).get_port_profile().name
+                    connectPorts(rh.port(sen.name), bridge.port(sen.name), subscription_type, rate=push_rate, pushpolicy=push_policy)
                 if sen.type == 'Force' and sh.port(sen.name+"Out") and bridge.port("ref_" + sen.name):
                     print program_name, "connect ", sen.name, sh.port(sen.name+"Out").get_port_profile().name, bridge.port("ref_" + sen.name).get_port_profile().name
                     connectPorts(sh.port(sen.name+"Out"), bridge.port("ref_" + sen.name), subscription_type, rate=push_rate, pushpolicy=push_policy) # for reference forces

--- a/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.h
+++ b/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.h
@@ -79,6 +79,7 @@ class HrpsysSeqStateROSBridge  : public HrpsysSeqStateROSBridgeImpl
   void clock_cb(const rosgraph_msgs::ClockPtr& str) {};
 
   bool follow_action_initialized;
+  bool is_rsforce_connected;
 
   boost::mutex tf_mutex;
   double tf_rate;


### PR DESCRIPTION
If rmfo is available, connect rmfo' force sensor ports instead of rh's force sensor ports.
Otherwise, connect rh's force sensor ports.

Background:
For Unstable RTC users, `off_rfsensor` from rmfo and `rfsensor` from rh are published.
However, unstable rtc users do not use `rfsensor` (not necessary).

Before this PR:
For unstable rtc users, rmfo's force sensor ports and rh's force sensor ports are connected to HrpsysSeqStateROSBridge and topics such as `off_rfsensor` and `rfsensor` are published.

After this PR:
For unstable rtc users, rmfo's force sensor ports are connected to HrpsysSeqStateROSBridge and topics such as `off_rfsensor` and `rfsensor` are published.
rmfo's values are copied to `rhsensor` for backward compatibility.


Behavior for stable rtc users does not change by this PR.

Related with: 
https://github.com/fkanehiro/hrpsys-base/pull/1057