### PR TITLE
add rsangle port to /HrpsysJointTrajectoryBridge to publish current j…

### DIFF
--- a/hrpsys_ros_bridge/launch/hrpsys_ros_bridge.launch
+++ b/hrpsys_ros_bridge/launch/hrpsys_ros_bridge.launch
@@ -113,6 +113,7 @@
           output="screen" args ="$(arg openrtm_args)" />
 
     <rtconnect from="$(arg SIMULATOR_NAME_ANGLE).rtc:q"     to="HrpsysSeqStateROSBridge0.rtc:rsangle" subscription_type="$(arg subscription_type)" push_policy="$(arg push_policy)" push_rate="$(arg push_rate)" buffer_length="$(arg buffer_length)"/>
+    <rtconnect from="$(arg SIMULATOR_NAME_ANGLE).rtc:q"     to="HrpsysJointTrajectoryBridge0.rtc:rsangle" subscription_type="$(arg subscription_type)" push_policy="$(arg push_policy)" push_rate="$(arg push_rate)" buffer_length="$(arg buffer_length)"/>
     <rtconnect from="$(arg SIMULATOR_NAME_VELOCITY).rtc:dq" to="HrpsysSeqStateROSBridge0.rtc:rsvel" subscription_type="$(arg subscription_type)" push_policy="$(arg push_policy)" push_rate="$(arg push_rate)" buffer_length="$(arg buffer_length)" if="$(arg USE_VELOCITY_OUTPUT)" />
     <rtconnect from="$(arg SIMULATOR_NAME_TORQUE).rtc:tau"  to="HrpsysSeqStateROSBridge0.rtc:rstorque" subscription_type="$(arg subscription_type)" push_policy="$(arg push_policy)" push_rate="$(arg push_rate)" buffer_length="$(arg buffer_length)" unless="$(arg USE_TORQUEFILTER)"/>
     <rtconnect from="StateHolderServiceROSBridge.rtc:StateHolderService" to="sh.rtc:StateHolderService"  subscription_type="new"/>

--- a/hrpsys_ros_bridge/src/HrpsysJointTrajectoryBridge.h
+++ b/hrpsys_ros_bridge/src/HrpsysJointTrajectoryBridge.h
@@ -115,8 +115,13 @@ public:
   };
 
 protected:
+  RTC::TimedDoubleSeq m_rsangle;
+  RTC::InPort<RTC::TimedDoubleSeq> m_rsangleIn;
+
   RTC::CorbaPort m_SequencePlayerServicePort;
   RTC::CorbaConsumer<OpenHRP::SequencePlayerService> m_service0;
+
+  std::string hrpsys_version;
 
 protected:
   hrp::BodyPtr body;


### PR DESCRIPTION
…oint angle in /feedback

This PR will publish /feedback with current joint angle, which we   only publish goal angle in current source code -> https://github.com/start-jsk/rtmros_common/pull/966

we need to add 'rsangle' RTM port in HrpsysJointTrajectory action, this might reduce performance ? in that case we need to integrate HrpsysJointTrajectory and HrpsysSeqStateROSBridge