### PR TITLE
Fix samplerobot hcf testing

### DIFF
--- a/hrpsys_ros_bridge/CMakeLists.txt
+++ b/hrpsys_ros_bridge/CMakeLists.txt
@@ -257,7 +257,11 @@ file(WRITE models/SampleRobot_controller_config.yaml
 
 add_rostest(test/test-samplerobot.test)
 if (NOT $ENV{ROS_DISTRO} STREQUAL "hydro")
-  add_rostest(test/test-samplerobot-hcf.launch) # hydro-deb does not work with --unstable-rtc
+  if ("true" STREQUAL "$ENV{USE_DEB}")
+    add_rostest(test/test-samplerobot-hcf.launch) # hydro-deb does not work with --unstable-rtc
+  else ()
+    add_rostest(test/test-samplerobot-hcf-unstable.launch) # unstable test does not work with deb
+  endif ()
 endif()
 add_rostest(test/test-pa10.test)
 add_rostest(test/test-import-python.test)

--- a/hrpsys_ros_bridge/test/test-samplerobot-hcf-unstable.launch
+++ b/hrpsys_ros_bridge/test/test-samplerobot-hcf-unstable.launch
@@ -1,0 +1,5 @@
+<launch>
+  <include file="$(find hrpsys_ros_bridge)/test/test-samplerobot-hcf.launch" >
+    <arg name="USE_UNSTABLE_RTC" default="true" />
+  </include>
+</launch>

--- a/hrpsys_ros_bridge/test/test-samplerobot-hcf.launch
+++ b/hrpsys_ros_bridge/test/test-samplerobot-hcf.launch
@@ -1,16 +1,19 @@
 <launch>
 
   <node name="start_omninames" pkg="rtmbuild" type="start_omninames.sh" args="2809" />
+  <arg name="USE_UNSTABLE_RTC" default="false" />
 
   <include file="$(find hrpsys_ros_bridge)/launch/samplerobot.launch" >
     <arg name="corbaport" default="2809" />
     <arg name="GUI" default="false" />
     <arg name="RUN_RVIZ" default="false" />
-    <arg name="USE_UNSTABLE_RTC" default="true" />
+    <arg name="USE_UNSTABLE_RTC" default="$(arg USE_UNSTABLE_RTC)" />
   </include>
 
   <node name="hrpsys_seq_state_ros_bridge_tf_relay" pkg="hrpsys_ros_bridge" type="hrpsys_seq_state_ros_bridge_tf_relay_for_test.py"/>
 
-  <test test-name="samplerobot_hcf" pkg="hrpsys_ros_bridge" type="test-samplerobot-hcf.py" retry="4" time-limit="300" args="-ORBInitRef NameService=corbaloc:iiop:localhost:2809/NameService"/>
+  <test test-name="samplerobot_hcf" pkg="hrpsys_ros_bridge" type="test-samplerobot-hcf.py" retry="4" time-limit="300" args="-ORBInitRef NameService=corbaloc:iiop:localhost:2809/NameService">
+    <param name="use_unstable_rtc" value="$(arg USE_UNSTABLE_RTC)" />
+  </test>
 
 </launch>

--- a/hrpsys_ros_bridge/test/test-samplerobot-hcf.py
+++ b/hrpsys_ros_bridge/test/test-samplerobot-hcf.py
@@ -29,10 +29,13 @@ class TestSampleRobotHcf(unittest.TestCase):
         pass
 
     def test_off_force_sensor(self):
-        while self.off_lfsensor == None:
-            time.sleep(1)
-            rospy.logwarn("wait for off_lfsensor...")
-        self.assertEqual(self.off_lfsensor.header.frame_id, "lfsensor")
+        if rospy.has_param("use_unstable_rtc") and rospy.getparam("use_unstable_rtc"):
+            while self.off_lfsensor == None:
+                time.sleep(1)
+                rospy.logwarn("wait for off_lfsensor...")
+            self.assertEqual(self.off_lfsensor.header.frame_id, "lfsensor")
+        else:
+            assert(True)
 
     def test_ref_force_sensor(self):
         while self.ref_lfsensor == None:
@@ -41,15 +44,18 @@ class TestSampleRobotHcf(unittest.TestCase):
         self.assertEqual(self.ref_lfsensor.header.frame_id, "lfsensor")
 
     def test_hcf_init(self):
-        hcf = samplerobot_hrpsys_config.SampleRobotHrpsysConfigurator()
-        model_url = rospkg.RosPack().get_path("openhrp3") + "/share/OpenHRP-3.1/sample/model/sample1.wrl"
-        if os.path.exists(model_url):
-            try:
-                hcf.init("SampleRobot(Robot)0", model_url)
-                assert(True)
-            except AttributeError as e:
-                print >> sys.stderr, "[test-samplerobot-hcf.py] catch exception", e
-                assert(False)
+        if rospy.has_param("use_unstable_rtc") and rospy.getparam("use_unstable_rtc"):
+            hcf = samplerobot_hrpsys_config.SampleRobotHrpsysConfigurator()
+            model_url = rospkg.RosPack().get_path("openhrp3") + "/share/OpenHRP-3.1/sample/model/sample1.wrl"
+            if os.path.exists(model_url):
+                try:
+                    hcf.init("SampleRobot(Robot)0", model_ur)
+                    assert(True)
+                except AttributeError as e:
+                    print >> sys.stderr, "[test-samplerobot-hcf.py] catch exception", e
+                    assert(False)
+        else:
+            assert(True)
 
 #unittest.main()
 if __name__ == '__main__':


### PR DESCRIPTION
こちら
https://github.com/start-jsk/rtmros_common/pull/941
の修正のPRです。

https://github.com/start-jsk/rtmros_common/pull/941#issuecomment-285535379
の後に思い出したものとして、
- samplerobot_hrpsys_config.pyのようなロボット固有のhrpsys pyは、Unstable RTC用
- stable RTCはそもそも固有の設定を必要としてない（実はseqのjointgroupはいりますが、現状デフォルトセットしてないので）ので、hrpsys_tools_config.pyを昔から使ってた

となっているので、そもそもsamplerobot_hrpsy_config.pyが呼ばれること自体がUnstable RTC用でした。
robot固有のsamplerobot_startup.launchなど
https://github.com/start-jsk/rtmros_common/blob/master/hrpsys_ros_bridge/cmake/compile_robot_model.cmake#L202
もそうなるようにcompile_robot_model.cmakeで生成されてます。

ということで、この部分でunstable かどうかでif文をかいて、
travis上ではUSE_DEBかどうかでunstableをチェックするかstableをチェックするかを
確認するようにしました。
試しにはしらせたtravisでは、このようなIF文でtest-samplerobot-hcfがよばれてそうなのを確認しました。