### PR TITLE
gen <robot>_hrpsys_ros_bridge based on hrpsys version

### DIFF
--- a/hrpsys_ros_bridge/cmake/compile_robot_model.cmake
+++ b/hrpsys_ros_bridge/cmake/compile_robot_model.cmake
@@ -209,6 +209,12 @@ macro (generate_default_launch_eusinterface_files wrlfile project_pkg_name)
   #  generate startup.launch
   configure_file(${hrpsys_ros_bridge_PACKAGE_PATH}/scripts/default_robot_startup.launch.in ${PROJECT_SOURCE_DIR}/launch/${_sname}_startup.launch)
   #  generate ros_bridge.launch
+  message("hrpsys_VERSION : ${hrpsys_VERSION}")
+  if("${hrpsys_VERSION}" VERSION_LESS "315.12.0")
+    set(HRPSYS_315_12_0 false)
+  else()
+    set(HRPSYS_315_12_0 true)
+  endif()
   configure_file(${hrpsys_ros_bridge_PACKAGE_PATH}/scripts/default_robot_ros_bridge.launch.in ${PROJECT_SOURCE_DIR}/launch/${_sname}_ros_bridge.launch)
   add_custom_target(${_sname}_${PROJECT_NAME}_compile_launch DEPENDS ${PROJECT_SOURCE_DIR}/launch/${_sname}_startup.launch ${PROJECT_SOURCE_DIR}/launch/${_sname}_ros_bridge.launch)
   #  generate toplevel launch which includes ros_bridge.launch and startup.launch

--- a/hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l
+++ b/hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l
@@ -818,30 +818,30 @@
     ))
   )
 
-;; ImpedanceController's ObjectTurnaroundDetector
-(def-set-get-param-method 'hrpsys_ros_bridge::OpenHRP_ImpedanceControllerService_objectTurnaroundDetectorParam
+;; ObjectContactTurnaroundDetector
+(def-set-get-param-method 'hrpsys_ros_bridge::OpenHRP_ObjectContactTurnaroundDetectorService_objectContactTurnaroundDetectorParam
   :set-object-turnaround-detector-param :get-object-turnaround-detector-param :get-object-turnaround-detector-param-arguments
-  :impedancecontrollerservice_setObjectTurnaroundDetectorParam
-  :impedancecontrollerservice_getObjectTurnaroundDetectorParam)
+  :ObjectContactTurnaroundDetectorService_setObjectContactTurnaroundDetectorParam
+  :ObjectContactTurnaroundDetectorService_getObjectContactTurnaroundDetectorParam)
 (defmethod rtm-ros-robot-interface
   (:start-object-turnaround-detection
    (&key (ref-diff-wrench) (max-time) (limbs))
-   "Start ObjectTurnaroundDetection mode.
+   "Start ObjectContactTurnaroundDetection mode.
     ref-diff-wrench is final reference wrench (scalar).
     max-time is max time [msec].
     limbs is limb list to be used."
-   (send self :impedancecontrollerservice_startObjectTurnaroundDetection
+   (send self :ObjectContactTurnaroundDetectorService_startObjectContactTurnaroundDetection
          :i_ref_diff_wrench ref-diff-wrench :i_max_time max-time :i_ee_names (mapcar #'string-downcase limbs)))
   (:check-object-turnaround-detection
    ()
-   "Check object turnaround detection.
+   "Check object contact turnaround detection.
    If t, detected. Otherwise, not detected."
    (send self :get-idl-enum-values
-         (send (send self :impedancecontrollerservice_checkObjectTurnaroundDetection) :operation_return)
-         "HRPSYS_ROS_BRIDGE::OPENHRP_IMPEDANCECONTROLLERSERVICE_DETECTORMODE"))
+         (send (send self :ObjectContactTurnaroundDetectorService_checkObjectContactTurnaroundDetection) :operation_return)
+         "HRPSYS_ROS_BRIDGE::OPENHRP_OBJECTCONTACTTURNAROUNDDETECTORSERVICE_DETECTORMODE"))
   (:get-otd-object-forces-moments
    ()
-   "Get ObjectTurnaroundDetector's curernt forces and moments for used limbs.
+   "Get ObjectContactTurnaroundDetector's curernt forces and moments for used limbs.
     Return value is (list force-list moment-list)."
    (labels ((split-vector
              (vec &optional (dim 3))
@@ -849,7 +849,7 @@
                (dotimes (i (/ (length vec) dim))
                  (push (subseq vec (* i 3) (+ (* i 3) 3)) vret))
                (reverse vret))))
-     (let ((ret (send self :impedancecontrollerservice_getObjectForcesMoments)))
+     (let ((ret (send self :ObjectContactTurnaroundDetectorService_getObjectForcesMoments)))
        (list (split-vector (send (send ret :o_forces) :data))
              (split-vector (send (send ret :o_moments) :data))
              (send ret :o_3dofwrench))

--- a/hrpsys_ros_bridge/launch/hrpsys_ros_bridge.launch
+++ b/hrpsys_ros_bridge/launch/hrpsys_ros_bridge.launch
@@ -27,7 +27,8 @@
   <arg name="USE_TORQUEFILTER" default="false" />
   <arg name="USE_IMAGESENSOR" default="false" />
   <arg name="USE_EMERGENCYSTOPPER" default="false" />
-  <arg name="USE_MANIPULATION" default="false" />
+  <arg name="USE_REFERENCEFORCEUPDATER" default="false" />
+  <arg name="USE_OBJECTCONTACTTURNAROUNDDETECTOR" default="false" />
   <arg name="USE_HRPSYS_PROFILE" default="true" />
   <arg name="USE_VELOCITY_OUTPUT" default="false" />
   <arg name="PUBLISH_SENSOR_TF" default="true" />
@@ -91,7 +92,7 @@
   <env name="push_policy" value="$(arg push_policy)" />
   <env name="push_rate" value="$(arg push_rate)" />
   <env name="buffer_length" value="$(arg buffer_length)" />
-  <node name="rtmlaunch_hrpsys_ros_bridge" pkg="openrtm_tools" type="rtmlaunch.py" args="$(find hrpsys_ros_bridge)/launch/hrpsys_ros_bridge.launch USE_COMMON=$(arg USE_COMMON) USE_WALKING=$(arg USE_WALKING) USE_COLLISIONCHECK=$(arg USE_COLLISIONCHECK) USE_IMPEDANCECONTROLLER=$(arg USE_IMPEDANCECONTROLLER) USE_SOFTERRORLIMIT=$(arg USE_SOFTERRORLIMIT) USE_IMAGESENSOR=$(arg USE_IMAGESENSOR) USE_ROBOTHARDWARE=$(arg USE_ROBOTHARDWARE) USE_GRASPCONTROLLER=$(arg USE_GRASPCONTROLLER) USE_SERVOCONTROLLER=$(arg USE_SERVOCONTROLLER) USE_TORQUECONTROLLER=$(arg USE_TORQUECONTROLLER) USE_TORQUEFILTER=$(arg USE_TORQUEFILTER) USE_EMERGENCYSTOPPER=$(arg USE_EMERGENCYSTOPPER) USE_MANIPULATION=$(arg USE_MANIPULATION) USE_VELOCITY_OUTPUT=$(arg USE_VELOCITY_OUTPUT)" output="$(arg OUTPUT)"/>
+  <node name="rtmlaunch_hrpsys_ros_bridge" pkg="openrtm_tools" type="rtmlaunch.py" args="$(find hrpsys_ros_bridge)/launch/hrpsys_ros_bridge.launch USE_COMMON=$(arg USE_COMMON) USE_WALKING=$(arg USE_WALKING) USE_COLLISIONCHECK=$(arg USE_COLLISIONCHECK) USE_IMPEDANCECONTROLLER=$(arg USE_IMPEDANCECONTROLLER) USE_SOFTERRORLIMIT=$(arg USE_SOFTERRORLIMIT) USE_IMAGESENSOR=$(arg USE_IMAGESENSOR) USE_ROBOTHARDWARE=$(arg USE_ROBOTHARDWARE) USE_GRASPCONTROLLER=$(arg USE_GRASPCONTROLLER) USE_SERVOCONTROLLER=$(arg USE_SERVOCONTROLLER) USE_TORQUECONTROLLER=$(arg USE_TORQUECONTROLLER) USE_TORQUEFILTER=$(arg USE_TORQUEFILTER) USE_EMERGENCYSTOPPER=$(arg USE_EMERGENCYSTOPPER) USE_REFERENCEFORCEUPDATER=$(arg USE_REFERENCEFORCEUPDATER) USE_OBJECTCONTACTTURNAROUNDDETECTOR=$(arg USE_OBJECTCONTACTTURNAROUNDDETECTOR) USE_VELOCITY_OUTPUT=$(arg USE_VELOCITY_OUTPUT)" output="$(arg OUTPUT)"/>
 
 
   <!-- All Robots -->
@@ -260,11 +261,13 @@
     <rtactivate component="HardEmergencyStopperServiceROSBridge.rtc" />
   </group>
 
-  <group if="$(arg USE_MANIPULATION)" >
+  <group if="$(arg USE_REFERENCEFORCEUPDATER)" >
     <node pkg="hrpsys_ros_bridge" name="ReferenceForceUpdaterServiceROSBridge" type="ReferenceForceUpdaterServiceROSBridgeComp"
           output="screen" args ="$(arg openrtm_args)" />
     <rtconnect from="ReferenceForceUpdaterServiceROSBridge.rtc:ReferenceForceUpdaterService" to="rfu.rtc:ReferenceForceUpdaterService"  subscription_type="new"/>
     <rtactivate component="ReferenceForceUpdaterServiceROSBridge.rtc" />
+  </group>
+  <group if="$(arg USE_OBJECTCONTACTTURNAROUNDDETECTOR)" >
     <node pkg="hrpsys_ros_bridge" name="ObjectContactTurnaroundDetectorServiceROSBridge" type="ObjectContactTurnaroundDetectorServiceROSBridgeComp"
           output="screen" args ="$(arg openrtm_args)" />
     <rtconnect from="ObjectContactTurnaroundDetectorServiceROSBridge.rtc:ObjectContactTurnaroundDetectorService" to="octd.rtc:ObjectContactTurnaroundDetectorService"  subscription_type="new"/>

--- a/hrpsys_ros_bridge/launch/hrpsys_ros_bridge.launch
+++ b/hrpsys_ros_bridge/launch/hrpsys_ros_bridge.launch
@@ -27,7 +27,7 @@
   <arg name="USE_TORQUEFILTER" default="false" />
   <arg name="USE_IMAGESENSOR" default="false" />
   <arg name="USE_EMERGENCYSTOPPER" default="false" />
-  <arg name="USE_REFERENCEFORCEUPDATER" default="false" />
+  <arg name="USE_MANIPULATION" default="false" />
   <arg name="USE_HRPSYS_PROFILE" default="true" />
   <arg name="USE_VELOCITY_OUTPUT" default="false" />
   <arg name="PUBLISH_SENSOR_TF" default="true" />
@@ -91,7 +91,7 @@
   <env name="push_policy" value="$(arg push_policy)" />
   <env name="push_rate" value="$(arg push_rate)" />
   <env name="buffer_length" value="$(arg buffer_length)" />
-  <node name="rtmlaunch_hrpsys_ros_bridge" pkg="openrtm_tools" type="rtmlaunch.py" args="$(find hrpsys_ros_bridge)/launch/hrpsys_ros_bridge.launch USE_COMMON=$(arg USE_COMMON) USE_WALKING=$(arg USE_WALKING) USE_COLLISIONCHECK=$(arg USE_COLLISIONCHECK) USE_IMPEDANCECONTROLLER=$(arg USE_IMPEDANCECONTROLLER) USE_SOFTERRORLIMIT=$(arg USE_SOFTERRORLIMIT) USE_IMAGESENSOR=$(arg USE_IMAGESENSOR) USE_ROBOTHARDWARE=$(arg USE_ROBOTHARDWARE) USE_GRASPCONTROLLER=$(arg USE_GRASPCONTROLLER) USE_SERVOCONTROLLER=$(arg USE_SERVOCONTROLLER) USE_TORQUECONTROLLER=$(arg USE_TORQUECONTROLLER) USE_TORQUEFILTER=$(arg USE_TORQUEFILTER) USE_EMERGENCYSTOPPER=$(arg USE_EMERGENCYSTOPPER) USE_REFERENCEFORCEUPDATER=$(arg USE_REFERENCEFORCEUPDATER) USE_VELOCITY_OUTPUT=$(arg USE_VELOCITY_OUTPUT)" output="$(arg OUTPUT)"/>
+  <node name="rtmlaunch_hrpsys_ros_bridge" pkg="openrtm_tools" type="rtmlaunch.py" args="$(find hrpsys_ros_bridge)/launch/hrpsys_ros_bridge.launch USE_COMMON=$(arg USE_COMMON) USE_WALKING=$(arg USE_WALKING) USE_COLLISIONCHECK=$(arg USE_COLLISIONCHECK) USE_IMPEDANCECONTROLLER=$(arg USE_IMPEDANCECONTROLLER) USE_SOFTERRORLIMIT=$(arg USE_SOFTERRORLIMIT) USE_IMAGESENSOR=$(arg USE_IMAGESENSOR) USE_ROBOTHARDWARE=$(arg USE_ROBOTHARDWARE) USE_GRASPCONTROLLER=$(arg USE_GRASPCONTROLLER) USE_SERVOCONTROLLER=$(arg USE_SERVOCONTROLLER) USE_TORQUECONTROLLER=$(arg USE_TORQUECONTROLLER) USE_TORQUEFILTER=$(arg USE_TORQUEFILTER) USE_EMERGENCYSTOPPER=$(arg USE_EMERGENCYSTOPPER) USE_MANIPULATION=$(arg USE_MANIPULATION) USE_VELOCITY_OUTPUT=$(arg USE_VELOCITY_OUTPUT)" output="$(arg OUTPUT)"/>
 
 
   <!-- All Robots -->
@@ -260,11 +260,15 @@
     <rtactivate component="HardEmergencyStopperServiceROSBridge.rtc" />
   </group>
 
-  <group if="$(arg USE_REFERENCEFORCEUPDATER)" >
+  <group if="$(arg USE_MANIPULATION)" >
     <node pkg="hrpsys_ros_bridge" name="ReferenceForceUpdaterServiceROSBridge" type="ReferenceForceUpdaterServiceROSBridgeComp"
           output="screen" args ="$(arg openrtm_args)" />
     <rtconnect from="ReferenceForceUpdaterServiceROSBridge.rtc:ReferenceForceUpdaterService" to="rfu.rtc:ReferenceForceUpdaterService"  subscription_type="new"/>
     <rtactivate component="ReferenceForceUpdaterServiceROSBridge.rtc" />
+    <node pkg="hrpsys_ros_bridge" name="ObjectContactTurnaroundDetectorServiceROSBridge" type="ObjectContactTurnaroundDetectorServiceROSBridgeComp"
+          output="screen" args ="$(arg openrtm_args)" />
+    <rtconnect from="ObjectContactTurnaroundDetectorServiceROSBridge.rtc:ObjectContactTurnaroundDetectorService" to="octd.rtc:ObjectContactTurnaroundDetectorService"  subscription_type="new"/>
+    <rtactivate component="ObjectContactTurnaroundDetectorServiceROSBridge.rtc" />
   </group>
 
   <!-- USER_IMAGESENSOR

--- a/hrpsys_ros_bridge/scripts/default_robot_ros_bridge.launch.in
+++ b/hrpsys_ros_bridge/scripts/default_robot_ros_bridge.launch.in
@@ -17,7 +17,9 @@
     <arg name="USE_WALKING" default="true" if="$(arg USE_UNSTABLE_RTC)"/>
     <arg name="USE_IMPEDANCECONTROLLER" default="true" if="$(arg USE_UNSTABLE_RTC)" />
     <arg name="USE_EMERGENCYSTOPPER" default="true" if="$(arg USE_UNSTABLE_RTC)" />
-    <arg name="USE_MANIPULATION" default="true" if="$(arg USE_UNSTABLE_RTC)" />
+    <arg name="USE_REFERENCEFORCEUPDATER" default="true" if="$(arg USE_UNSTABLE_RTC)" />
+    <!-- OBJECTCONTACTTURNAROUNDDETECTOR is not included in unstable, still under development -->
+    <!-- <arg name="USE_OBJECTCONTACTTURNAROUNDDETECTOR" default="true" if="$(arg USE_UNSTABLE_RTC)" /> -->
     <arg name="ROBOT_TYPE" default="@robot@" if="$(arg USE_UNSTABLE_RTC)" />
     <arg name="USE_ROBOT_TYPE_SETTING" default="true" if="$(arg USE_UNSTABLE_RTC)" />
 @ROSBRIDGE_ARGS@

--- a/hrpsys_ros_bridge/scripts/default_robot_ros_bridge.launch.in
+++ b/hrpsys_ros_bridge/scripts/default_robot_ros_bridge.launch.in
@@ -2,6 +2,8 @@
   <arg name="RUN_RVIZ" default="true" />
   <arg name="SIMULATOR_NAME" default="@ROBOT@(Robot)0" />
   <arg name="USE_UNSTABLE_RTC" default="@USE_UNSTABLE_RTC@"/>
+  <arg     if="@HRPSYS_315_12_0@" name="USE_UNSTABLE_RTC_315_12_0" value="$(arg USE_UNSTABLE_RTC)"/>
+  <arg unless="@HRPSYS_315_12_0@" name="USE_UNSTABLE_RTC_315_12_0" value="false"/>
   <rosparam command="load"
             file="$(find @PROJECT_PKG_NAME@)/models/@ROBOT@_controller_config.yaml" />
 
@@ -18,8 +20,8 @@
     <arg name="USE_IMPEDANCECONTROLLER" default="true" if="$(arg USE_UNSTABLE_RTC)" />
     <arg name="USE_EMERGENCYSTOPPER" default="true" if="$(arg USE_UNSTABLE_RTC)" />
     <arg name="USE_REFERENCEFORCEUPDATER" default="true" if="$(arg USE_UNSTABLE_RTC)" />
-    <!-- OBJECTCONTACTTURNAROUNDDETECTOR is not included in unstable, still under development -->
-    <!-- <arg name="USE_OBJECTCONTACTTURNAROUNDDETECTOR" default="true" if="$(arg USE_UNSTABLE_RTC)" /> -->
+    <!-- ObjectContactTurnAroundDetector requires hrpsys 315.12.0 -->
+    <arg name="USE_OBJECTCONTACTTURNAROUNDDETECTOR" default="true" if="$(arg USE_UNSTABLE_RTC_315_12_0)" />
     <arg name="ROBOT_TYPE" default="@robot@" if="$(arg USE_UNSTABLE_RTC)" />
     <arg name="USE_ROBOT_TYPE_SETTING" default="true" if="$(arg USE_UNSTABLE_RTC)" />
 @ROSBRIDGE_ARGS@

--- a/hrpsys_ros_bridge/scripts/default_robot_ros_bridge.launch.in
+++ b/hrpsys_ros_bridge/scripts/default_robot_ros_bridge.launch.in
@@ -17,7 +17,7 @@
     <arg name="USE_WALKING" default="true" if="$(arg USE_UNSTABLE_RTC)"/>
     <arg name="USE_IMPEDANCECONTROLLER" default="true" if="$(arg USE_UNSTABLE_RTC)" />
     <arg name="USE_EMERGENCYSTOPPER" default="true" if="$(arg USE_UNSTABLE_RTC)" />
-    <arg name="USE_REFERENCEFORCEUPDATER" default="true" if="$(arg USE_UNSTABLE_RTC)" />
+    <arg name="USE_MANIPULATION" default="true" if="$(arg USE_UNSTABLE_RTC)" />
     <arg name="ROBOT_TYPE" default="@robot@" if="$(arg USE_UNSTABLE_RTC)" />
     <arg name="USE_ROBOT_TYPE_SETTING" default="true" if="$(arg USE_UNSTABLE_RTC)" />
 @ROSBRIDGE_ARGS@

--- a/hrpsys_tools/launch/hrpsys.launch
+++ b/hrpsys_tools/launch/hrpsys.launch
@@ -71,6 +71,7 @@
 -o "example.PDcontroller.config_file:$(arg CONF_FILE)"
 -o "example.EmergencyStopper.config_file:$(arg CONF_FILE)"
 -o "example.ReferenceForceUpdater.config_file:$(arg CONF_FILE)"
+-o "example.ObjectContactTurnaroundDetector.config_file:$(arg CONF_FILE)"
 -o "example.RobotHardware.config_file:$(arg RobotHardware_conf)"
     '/>
   <arg name="hrpsys_opt_rtc_config_args" default=''/>


### PR DESCRIPTION
- use ObjectContactTurnAroundDetector if hrpsys >= 315.12.0
-  back to use USE_OBJECTCONTACTTURNAROUNDDETECTOR, instead of USE_MANIPULATOR
- [hrpsys_ros_bridge/launch/hrpsys_ros_bridge.launch,hrpsys_ros_bridge/scripts/default_robot_ros_bridge.launch.in,hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l,hrpsys_tools/launch/hrpsys.launch]
 Update for ObjectTurnaroundDetector RTC. Merge USE_REFERENCEFORCEUDPATER  flag to USE_MANIPULATION flag.