### PR TITLE
[.travis_test.sh] Update location of downstream test file

### DIFF
--- a/.travis_test.sh
+++ b/.travis_test.sh
@@ -52,7 +52,7 @@ if [ "$TEST_TYPE" == "work_with_downstream" ]; then
     sudo dpkg -r --force-depends ros-$ROS_DISTRO-hrpsys-tools
     sudo dpkg -r --force-depends ros-$ROS_DISTRO-rtmbuild
     # https://github.com/start-jsk/rtmros_hironx/issues/287
-    sudo sed -i s@test_tf_and_controller@_test_tf_and_controller@ /opt/ros/$ROS_DISTRO/share/hironx_ros_bridge/test/test_hironx_ros_bridge.py
+    sudo sed -i s@test_tf_and_controller@_test_tf_and_controller@ /opt/ros/$ROS_DISTRO/lib/python2.7/dist-packages/hironx_ros_bridge/testutil/test_hironx_ros_bridge.py
     catkin_make $ROS_PARALLEL_JOBS
     catkin_make install $ROS_PARALLEL_JOBS
 else


### PR DESCRIPTION
上流から参照されているとは思い浮かばずすみません．この件はこの PR を取り込むのが一番早く問題解決できる (他の package の deb ができるのを待つ必要は無い等) と思います．

**Issue**
Test started failing https://github.com/start-jsk/rtmros_common/pull/1005#issuecomment-291125406

**Root cause**
A test file in downstream that is referred to from a test within this package is moved to another location.

**Background of the rootcause**
As noted at https://github.com/start-jsk/rtmros_hironx/pull/490#issue-216638080, `hironx_ros_bridge/test/test_hironx_ros_bridge.py` provides a test class that is beneficial for other Hiro-Nextage packages if they can reference to.

I thought/thinks it was perfectly reasonable to make the file installed as referrable for the following reasons:

- That file was not installed via `setup.sh`, which means it was not made as referrable as a Python module from external packages.
- Test at the repository passed for https://github.com/start-jsk/rtmros_hironx/pull/490

**Solution in this commit**
Update the location of the downstream test file to be referenced.