### PR TITLE
[hrpsys_ros_bridge] Ignore invalid sensor id in onInitialize function

### DIFF
--- a/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridgeImpl.cpp
+++ b/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridgeImpl.cpp
@@ -163,6 +163,9 @@ RTC::ReturnCode_t HrpsysSeqStateROSBridgeImpl::onInitialize()
   for (int j = 0 ; j < body->numSensorTypes(); j++) {
     for (int i = 0 ; i < body->numSensors(j); i++) {
       hrp::Sensor* sensor = body->sensor(j, i);
+      if (sensor == NULL) {
+        continue; // invalid sensor id
+      }
       SensorInfo si;
       si.transform.setOrigin( tf::Vector3(sensor->localPos(0), sensor->localPos(1), sensor->localPos(2)) );
       hrp::Vector3 rpy;


### PR DESCRIPTION
HrpsysSeqStateROSBridge receives SEGV when sensor id is not numbered consecutively