### PR TITLE
[HrpsysSeqStateROSBridge] remove subtraction magic number

### DIFF
--- a/hrpsys_ros_bridge/src/HrpsysJointTrajectoryBridge.cpp
+++ b/hrpsys_ros_bridge/src/HrpsysJointTrajectoryBridge.cpp
@@ -449,14 +449,7 @@ void HrpsysJointTrajectoryBridge::jointTrajectoryActionObj::onJointTrajectory(
     }
     else
     { // if i == 0
-      if (trajectory.points.size() == 1)
-      {
-        duration[i] = trajectory.points[i].time_from_start.toSec();
-      }
-      else
-      { // 0.2 is magic number writtein in roseus/euslisp/robot-interface.l
-        duration[i] = trajectory.points[i].time_from_start.toSec() - 0.2;
-      }
+      duration[i] = trajectory.points[i].time_from_start.toSec();
     }
   }
 

--- a/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.cpp
+++ b/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.cpp
@@ -192,11 +192,7 @@ void HrpsysSeqStateROSBridge::onJointTrajectory(trajectory_msgs::JointTrajectory
     if ( i > 0 ) {
       duration[i] =  trajectory.points[i].time_from_start.toSec() - trajectory.points[i-1].time_from_start.toSec();
     } else { // if i == 0
-      if ( trajectory.points.size()== 1 ) {
-	duration[i] = trajectory.points[i].time_from_start.toSec();
-      } else { // 0.2 is magic number writtein in roseus/euslisp/robot-interface.l
-	duration[i] = trajectory.points[i].time_from_start.toSec() - 0.2;
-      }
+      duration[i] = trajectory.points[i].time_from_start.toSec();
     }
   }
 


### PR DESCRIPTION
0.2 which is magic number written in pr2eus/robot-interface.l is no longer used.
If a sequence with less than 0.2 duration is sent, sequence_player may work unexpectedly.
Especially, first duration is 0.2,  division by zero occurs and sequencer output NaN.