### PR TITLE
use language: c++ , to avoid custom python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@
 #   Author: Dave Coleman, Jonathan Bohren
 sudo: required
 dist: trusty
-language: generic
+language: c++
 cache:
   - ccache
   - apt


### PR DESCRIPTION
need to use system python, with travis-python we can not find python module install by apt
c.f. jsk-ros-pkg/jsk_3rdparty#117