### PR TITLE
fix code to run both Indido and Kinetic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,16 +29,15 @@ env:
     - USE_TRAVIS=true ROS_DISTRO=indigo USE_DEB=true    EXTRA_DEB="ros-indigo-hrpsys-ros-bridge ros-indigo-pr2eus" CATKIN_PARALLEL_JOBS='-p4' NOT_TEST_INSTALL=true IS_EUSLISP_TRAVIS_TEST="true"
     - USE_JENKINS=true ROS_DISTRO=indigo USE_DEB=false   EXTRA_DEB="ros-indigo-hrpsys-ros-bridge ros-indigo-pr2eus" ROS_PARALLEL_JOBS="-j1 -l1" NOT_TEST_INSTALL=true IS_EUSLISP_TRAVIS_TEST="true"
     - USE_TRAVIS=true ROS_DISTRO=jade   USE_DEB=true
-    - USE_JENKINS=true ROS_DISTRO=kinetic USE_DEB=true
     - USE_TRAVIS=true TEST_TYPE=work_with_downstream  TEST_PACKAGE=hironx-ros-bridge ROS_DISTRO=indigo EXTRA_DEB="ros-indigo-roslint"
     - USE_TRAVIS=true TEST_TYPE=work_with_315_1_10    TEST_PACKAGE=hironx-ros-bridge ROS_DISTRO=indigo EXTRA_DEB="ros-indigo-roslint"
     - USE_TRAVIS=true TEST_TYPE=work_with_downstream  TEST_PACKAGE=hironx-ros-bridge ROS_DISTRO=jade EXTRA_DEB="ros-jade-roslint"
     - USE_TRAVIS=true TEST_TYPE=work_with_315_1_10    TEST_PACKAGE=hironx-ros-bridge ROS_DISTRO=jade EXTRA_DEB="ros-jade-roslint"
     - USE_JENKINS=true ROS_DISTRO=hydro  USE_DEB=true  EXTRA_DEB="ros-hydro-pr2eus"
+    - USE_JENKINS=true ROS_DISTRO=kinetic USE_DEB=true
 matrix:
   allow_failures:
   - env: USE_TRAVIS=true ROS_DISTRO=indigo USE_DEB=true    EXTRA_DEB="ros-indigo-hrpsys-ros-bridge ros-indigo-pr2eus" CATKIN_PARALLEL_JOBS='-p4' NOT_TEST_INSTALL=true IS_EUSLISP_TRAVIS_TEST="true"
-  - env: USE_JENKINS=true ROS_DISTRO=kinetic USE_DEB=true
   - env: USE_TRAVIS=true TEST_TYPE=work_with_downstream  TEST_PACKAGE=hironx-ros-bridge ROS_DISTRO=jade EXTRA_DEB="ros-jade-roslint"
   - env: USE_TRAVIS=true TEST_TYPE=work_with_315_1_10    TEST_PACKAGE=hironx-ros-bridge ROS_DISTRO=jade EXTRA_DEB="ros-jade-roslint"
 notifications:

--- a/hrpsys_ros_bridge/CMakeLists.txt
+++ b/hrpsys_ros_bridge/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(hrpsys_ros_bridge)
 
 # call catkin depends
-find_package(catkin REQUIRED COMPONENTS rtmbuild roscpp rostest sensor_msgs robot_state_publisher actionlib control_msgs tf camera_info_manager hrpsys_tools image_transport dynamic_reconfigure nav_msgs geometry_msgs pr2_controllers_msgs pr2_msgs) # robot_monitor
+find_package(catkin REQUIRED COMPONENTS rtmbuild roscpp rostest sensor_msgs robot_state_publisher actionlib control_msgs tf camera_info_manager hrpsys_tools image_transport dynamic_reconfigure nav_msgs geometry_msgs pr2_controllers_msgs) # robot_monitor
 find_package(hrpsys QUIET) # on indigo, hrpsys is not ros package
 if(NOT ${hrpsys_FOUND})
   find_package(PkgConfig)

--- a/hrpsys_ros_bridge/CMakeLists.txt
+++ b/hrpsys_ros_bridge/CMakeLists.txt
@@ -12,20 +12,6 @@ endif()
 
 catkin_python_setup()
 
-# download pr2_controllers_msgs for git
-find_package(pr2_controllers_msgs QUIET)
-if(NOT pr2_controllers_msgs_FOUND)
-  download_pr2_controllers_msgs(hydro-devel) # even for Groovy, download hydro-devel that's wet.
-  # catkin_make
-  # rosmake pr2_controllers_msgs
-  execute_process(COMMAND cmake -E chdir ${CMAKE_SOURCE_DIR}/../ catkin_make -C ${CMAKE_SOURCE_DIR}/../ --build /tmp/pr2_controllers --source ${PROJECT_SOURCE_DIR}/../pr2_controllers_msgs --pkg pr2_controllers_msgs OUTPUT_VARIABLE _compile_output RESULT_VARIABLE _compile_failed)
-  message("compile pr2_controllers_msgs ${_compile_output}")
-  if (_compile_failed)
-    message(FATAL_ERROR "compile pr2_controllers_msgs failed : ${_compile_failed}")
-  endif(_compile_failed)
- include_directories(${CMAKE_SOURCE_DIR}/../devel/include)
-endif()
-
 # include rtmbuild
 #include(${rtmbuild_PREFIX}/share/rtmbuild/cmake/rtmbuild.cmake)
 if(EXISTS ${rtmbuild_SOURCE_DIR}/cmake/rtmbuild.cmake)

--- a/hrpsys_ros_bridge/CMakeLists.txt
+++ b/hrpsys_ros_bridge/CMakeLists.txt
@@ -3,7 +3,14 @@ cmake_minimum_required(VERSION 2.8.3)
 project(hrpsys_ros_bridge)
 
 # call catkin depends
-find_package(catkin REQUIRED COMPONENTS rtmbuild roscpp rostest sensor_msgs robot_state_publisher actionlib control_msgs tf camera_info_manager hrpsys_tools image_transport dynamic_reconfigure nav_msgs geometry_msgs pr2_controllers_msgs) # robot_monitor
+find_package(catkin QUIET COMPONENTS pr2_controllers_msgs)
+if(pr2_controllers_msgs_FOUND)
+  set(PR2_CONTROLLERS_MSGS_PACKAGE pr2_controllers_msgs)
+  add_definitions("-DUSE_PR2_CONTROLLERS_MSGS")
+endif()
+message(STATUS "check for pr2 messages, will compile with ${PR2_CONTROLLERS_MSGS_PACKAGE}.")
+
+find_package(catkin REQUIRED COMPONENTS rtmbuild roscpp rostest sensor_msgs robot_state_publisher actionlib control_msgs tf camera_info_manager hrpsys_tools image_transport dynamic_reconfigure nav_msgs geometry_msgs ${PR2_CONTROLLERS_MSGS_PACKAGE}) # robot_monitor
 find_package(hrpsys QUIET) # on indigo, hrpsys is not ros package
 if(NOT ${hrpsys_FOUND})
   find_package(PkgConfig)
@@ -77,7 +84,7 @@ rtmbuild_init(geometry_msgs)
 # call catkin_package, after rtmbuild_init, before rtmbuild_gen*
 catkin_package(
     DEPENDS hrpsys # TODO
-    CATKIN_DEPENDS rtmbuild roscpp sensor_msgs robot_state_publisher actionlib control_msgs tf camera_info_manager image_transport dynamic_reconfigure nav_msgs pr2_controllers_msgs #robot_monitor
+    CATKIN_DEPENDS rtmbuild roscpp sensor_msgs robot_state_publisher actionlib control_msgs tf camera_info_manager image_transport dynamic_reconfigure nav_msgs ${PR2_CONTROLLERS_MSGS_PACKAGE} #robot_monitor
     INCLUDE_DIRS # TODO include
     LIBRARIES # TODO
     CFG_EXTRAS compile_robot_model.cmake

--- a/hrpsys_ros_bridge/src/HrpsysJointTrajectoryBridge.cpp
+++ b/hrpsys_ros_bridge/src/HrpsysJointTrajectoryBridge.cpp
@@ -220,26 +220,35 @@ HrpsysJointTrajectoryBridge::jointTrajectoryActionObj::jointTrajectoryActionObj(
   groupname = gname;
   joint_list = jlist;
 
+#ifdef USE_PR2_CONTROLLERS_MSGS
   joint_trajectory_server.reset(
       new actionlib::SimpleActionServer<pr2_controllers_msgs::JointTrajectoryAction>(
           parent->nh, controller_name + "/joint_trajectory_action", false));
+#endif
   follow_joint_trajectory_server.reset(
       new actionlib::SimpleActionServer<control_msgs::FollowJointTrajectoryAction>(
           parent->nh, controller_name + "/follow_joint_trajectory_action", false));
   trajectory_command_sub = parent->nh.subscribe(controller_name + "/command", 1, &HrpsysJointTrajectoryBridge::jointTrajectoryActionObj::onTrajectoryCommandCB, this);
 
 
+#ifdef USE_PR2_CONTROLLERS_MSGS
   joint_trajectory_server->registerGoalCallback(
       boost::bind(&HrpsysJointTrajectoryBridge::jointTrajectoryActionObj::onJointTrajectoryActionGoal, this));
   joint_trajectory_server->registerPreemptCallback(
       boost::bind(&HrpsysJointTrajectoryBridge::jointTrajectoryActionObj::onJointTrajectoryActionPreempt, this));
+#endif
   follow_joint_trajectory_server->registerGoalCallback(
       boost::bind(&HrpsysJointTrajectoryBridge::jointTrajectoryActionObj::onFollowJointTrajectoryActionGoal, this));
   follow_joint_trajectory_server->registerPreemptCallback(
       boost::bind(&HrpsysJointTrajectoryBridge::jointTrajectoryActionObj::onFollowJointTrajectoryActionPreempt, this));
 
+#ifdef USE_PR2_CONTROLLERS_MSGS
   joint_controller_state_pub = parent->nh.advertise<pr2_controllers_msgs::JointTrajectoryControllerState>(
       controller_name + "/state", 1);
+#else
+  joint_controller_state_pub = parent->nh.advertise<control_msgs::JointTrajectoryControllerState>(
+      controller_name + "/state", 1);
+#endif
 
   if (groupname.length() > 0)
   {
@@ -269,31 +278,37 @@ HrpsysJointTrajectoryBridge::jointTrajectoryActionObj::jointTrajectoryActionObj(
   }
 
   interpolationp = false;
-
+#ifdef USE_PR2_CONTROLLERS_MSGS
   joint_trajectory_server->start();
+#endif
   follow_joint_trajectory_server->start();
 }
 
 HrpsysJointTrajectoryBridge::jointTrajectoryActionObj::~jointTrajectoryActionObj()
 {
   ROS_INFO_STREAM("[" << parent->getInstanceName() << "] @~jointTrajectoryActionObj (" << this->groupname);
+#ifdef USE_PR2_CONTROLLERS_MSGS
   if (joint_trajectory_server->isActive())
   {
     joint_trajectory_server->setPreempted();
   }
+#endif
 
   if (follow_joint_trajectory_server->isActive())
   {
     follow_joint_trajectory_server->setPreempted();
   }
 
+#ifdef USE_PR2_CONTROLLERS_MSGS
   joint_trajectory_server->shutdown();
+#endif
   follow_joint_trajectory_server->shutdown();
 }
 
 void HrpsysJointTrajectoryBridge::jointTrajectoryActionObj::proc()
 {
   // finish interpolation
+#ifdef USE_PR2_CONTROLLERS_MSGS
   if (joint_trajectory_server->isActive() && interpolationp == true && parent->m_service0->isEmpty() == true)
   {
     pr2_controllers_msgs::JointTrajectoryResult result;
@@ -301,6 +316,7 @@ void HrpsysJointTrajectoryBridge::jointTrajectoryActionObj::proc()
     interpolationp = false;
     ROS_INFO_STREAM("[" << parent->getInstanceName() << "] @proc joint_trajectory_server->setSucceeded()");
   }
+#endif
   if (follow_joint_trajectory_server->isActive() && interpolationp == true && parent->m_service0->isEmpty() == true)
   {
     control_msgs::FollowJointTrajectoryResult result;
@@ -330,10 +346,12 @@ void HrpsysJointTrajectoryBridge::jointTrajectoryActionObj::proc()
   error_joint_trajectory_point.accelerations.resize(joint_list.size());
   error_joint_trajectory_point.effort.resize(joint_list.size());
 
+#ifdef USE_PR2_CONTROLLERS_MSGS
   if ( joint_trajectory_server->isActive() ) {
     pr2_controllers_msgs::JointTrajectoryFeedback joint_trajectory_feedback;
     joint_trajectory_server->publishFeedback(joint_trajectory_feedback);
   }
+#endif
 
   if ( follow_joint_trajectory_server->isActive() ) {
     control_msgs::FollowJointTrajectoryFeedback follow_joint_trajectory_feedback;
@@ -347,7 +365,11 @@ void HrpsysJointTrajectoryBridge::jointTrajectoryActionObj::proc()
     follow_joint_trajectory_server->publishFeedback(follow_joint_trajectory_feedback);
   }
 
+#ifdef USE_PR2_CONTROLLERS_MSGS
   pr2_controllers_msgs::JointTrajectoryControllerState joint_controller_state;
+#else
+  control_msgs::JointTrajectoryControllerState joint_controller_state;
+#endif
   joint_controller_state.joint_names = joint_list;
 
   joint_controller_state.desired = commanded_joint_trajectory_point;
@@ -483,12 +505,14 @@ void HrpsysJointTrajectoryBridge::jointTrajectoryActionObj::onJointTrajectory(
   interpolationp = true;
 }
 
+#ifdef USE_PR2_CONTROLLERS_MSGS
 void HrpsysJointTrajectoryBridge::jointTrajectoryActionObj::onJointTrajectoryActionGoal()
 {
   ROS_INFO_STREAM("[" << parent->getInstanceName() << "] @onJointTrajectoryActionGoal");
   pr2_controllers_msgs::JointTrajectoryGoalConstPtr goal = joint_trajectory_server->acceptNewGoal();
   onJointTrajectory(goal->trajectory);
 }
+#endif
 
 void HrpsysJointTrajectoryBridge::jointTrajectoryActionObj::onFollowJointTrajectoryActionGoal()
 {
@@ -497,11 +521,13 @@ void HrpsysJointTrajectoryBridge::jointTrajectoryActionObj::onFollowJointTraject
   onJointTrajectory(goal->trajectory);
 }
 
+#ifdef USE_PR2_CONTROLLERS_MSGS
 void HrpsysJointTrajectoryBridge::jointTrajectoryActionObj::onJointTrajectoryActionPreempt()
 {
   ROS_INFO_STREAM("[" << parent->getInstanceName() << "] @onJointTrajectoryActionPreempt()");
   joint_trajectory_server->setPreempted();
 }
+#endif
 
 void HrpsysJointTrajectoryBridge::jointTrajectoryActionObj::onFollowJointTrajectoryActionPreempt()
 {

--- a/hrpsys_ros_bridge/src/HrpsysJointTrajectoryBridge.h
+++ b/hrpsys_ros_bridge/src/HrpsysJointTrajectoryBridge.h
@@ -60,8 +60,12 @@
 #include "sensor_msgs/JointState.h"
 #include "control_msgs/FollowJointTrajectoryAction.h"
 #include "actionlib/server/simple_action_server.h"
+#ifdef USE_PR2_CONTROLLERS_MSGS
 #include "pr2_controllers_msgs/JointTrajectoryAction.h"
 #include "pr2_controllers_msgs/JointTrajectoryControllerState.h"
+#else
+#include "control_msgs/JointTrajectoryControllerState.h"
+#endif
 #include "trajectory_msgs/JointTrajectory.h"
 
 #include "hrpsys_ros_bridge/idl/SequencePlayerServiceStub.h"
@@ -88,7 +92,9 @@ public:
 
     ros::Publisher joint_controller_state_pub;
 
+#ifdef USE_PR2_CONTROLLERS_MSGS
     boost::shared_ptr<actionlib::SimpleActionServer<pr2_controllers_msgs::JointTrajectoryAction> > joint_trajectory_server;
+#endif
     boost::shared_ptr<actionlib::SimpleActionServer<control_msgs::FollowJointTrajectoryAction> > follow_joint_trajectory_server;
     ros::Subscriber trajectory_command_sub;
 
@@ -104,8 +110,10 @@ public:
     ~jointTrajectoryActionObj();
 
     void onJointTrajectory(trajectory_msgs::JointTrajectory trajectory);
+#ifdef USE_PR2_CONTROLLERS_MSGS
     void onJointTrajectoryActionGoal();
     void onJointTrajectoryActionPreempt();
+#endif
     void onFollowJointTrajectoryActionGoal();
     void onFollowJointTrajectoryActionPreempt();
     void onTrajectoryCommandCB(const trajectory_msgs::JointTrajectoryConstPtr& msg);

--- a/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.cpp
+++ b/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.cpp
@@ -32,7 +32,9 @@ static const char* hrpsysseqstaterosbridge_spec[] =
 
 HrpsysSeqStateROSBridge::HrpsysSeqStateROSBridge(RTC::Manager* manager) :
   use_sim_time(false), use_hrpsys_time(false),
+#ifdef USE_PR2_CONTROLLERS_MSGS
   joint_trajectory_server(nh, "fullbody_controller/joint_trajectory_action", false),
+#endif
   follow_joint_trajectory_server(nh, "fullbody_controller/follow_joint_trajectory_action", false),
   HrpsysSeqStateROSBridgeImpl(manager), follow_action_initialized(false), prev_odom_acquired(false)
 {
@@ -45,14 +47,20 @@ HrpsysSeqStateROSBridge::HrpsysSeqStateROSBridge(RTC::Manager* manager) :
   tf_transforms.clear();
   periodic_update_timer = pnh.createTimer(ros::Duration(1.0 / tf_rate), boost::bind(&HrpsysSeqStateROSBridge::periodicTimerCallback, this, _1));
   
+#ifdef USE_PR2_CONTROLLERS_MSGS
   joint_trajectory_server.registerGoalCallback(boost::bind(&HrpsysSeqStateROSBridge::onJointTrajectoryActionGoal, this));
   joint_trajectory_server.registerPreemptCallback(boost::bind(&HrpsysSeqStateROSBridge::onJointTrajectoryActionPreempt, this));
+#endif
   follow_joint_trajectory_server.registerGoalCallback(boost::bind(&HrpsysSeqStateROSBridge::onFollowJointTrajectoryActionGoal, this));
   follow_joint_trajectory_server.registerPreemptCallback(boost::bind(&HrpsysSeqStateROSBridge::onFollowJointTrajectoryActionPreempt, this));
   sendmsg_srv = nh.advertiseService(std::string("sendmsg"), &HrpsysSeqStateROSBridge::sendMsg, this);
   set_sensor_transformation_srv = nh.advertiseService("set_sensor_transformation", &HrpsysSeqStateROSBridge::setSensorTransformation, this);
   joint_state_pub = nh.advertise<sensor_msgs::JointState>("joint_states", 1);
+#ifdef USE_PR2_CONTROLLERS_MSGS
   joint_controller_state_pub = nh.advertise<pr2_controllers_msgs::JointTrajectoryControllerState>("/fullbody_controller/state", 1);
+#else
+  joint_controller_state_pub = nh.advertise<control_msgs::JointTrajectoryControllerState>("/fullbody_controller/state", 1);
+#endif
   trajectory_command_sub = nh.subscribe("/fullbody_controller/command", 1, &HrpsysSeqStateROSBridge::onTrajectoryCommandCB, this);
   mot_states_pub = nh.advertise<hrpsys_ros_bridge::MotorStates>("/motor_states", 1);
   odom_pub = nh.advertise<nav_msgs::Odometry>("/odom", 1);
@@ -87,21 +95,26 @@ HrpsysSeqStateROSBridge::HrpsysSeqStateROSBridge(RTC::Manager* manager) :
         ROS_WARN("[HrpsysSeqStateROSBridge] use_sim_time");
       }
   }
+#ifdef USE_PR2_CONTROLLERS_MSGS
   joint_trajectory_server.start();
+#endif
   follow_joint_trajectory_server.start();
 }
 
 HrpsysSeqStateROSBridge::~HrpsysSeqStateROSBridge() {
+#ifdef USE_PR2_CONTROLLERS_MSGS
   joint_trajectory_server.shutdown();
+#endif
   follow_joint_trajectory_server.shutdown();
 };
 
 RTC::ReturnCode_t HrpsysSeqStateROSBridge::onFinalize() {
   ROS_INFO_STREAM("[HrpsysSeqStateROSBridge] @onFinalize : " << getInstanceName());
+#ifdef USE_PR2_CONTROLLERS_MSGS
   if ( joint_trajectory_server.isActive() ) {
       joint_trajectory_server.setPreempted();
   }
-
+#endif
   if (   follow_joint_trajectory_server.isActive() ) {
       follow_joint_trajectory_server.setPreempted();
   }
@@ -208,10 +221,12 @@ void HrpsysSeqStateROSBridge::onJointTrajectory(trajectory_msgs::JointTrajectory
   interpolationp = true;
 }
 
+#ifdef USE_PR2_CONTROLLERS_MSGS
 void HrpsysSeqStateROSBridge::onJointTrajectoryActionGoal() {
   pr2_controllers_msgs::JointTrajectoryGoalConstPtr goal = joint_trajectory_server.acceptNewGoal();
   onJointTrajectory(goal->trajectory);
 }
+#endif
 
 void HrpsysSeqStateROSBridge::onFollowJointTrajectoryActionGoal() {
   control_msgs::FollowJointTrajectoryGoalConstPtr goal = follow_joint_trajectory_server.acceptNewGoal();
@@ -219,9 +234,11 @@ void HrpsysSeqStateROSBridge::onFollowJointTrajectoryActionGoal() {
   onJointTrajectory(goal->trajectory);
 }
 
+#ifdef USE_PR2_CONTROLLERS_MSGS
 void HrpsysSeqStateROSBridge::onJointTrajectoryActionPreempt() {
   joint_trajectory_server.setPreempted();
 }
+#endif
 
 void HrpsysSeqStateROSBridge::onFollowJointTrajectoryActionPreempt() {
   follow_joint_trajectory_server.setPreempted();
@@ -275,7 +292,11 @@ bool HrpsysSeqStateROSBridge::sendMsg (dynamic_reconfigure::Reconfigure::Request
 RTC::ReturnCode_t HrpsysSeqStateROSBridge::onExecute(RTC::UniqueId ec_id)
 {
   ros::Time tm_on_execute = ros::Time::now();
+#ifdef USE_PR2_CONTROLLERS_MSGS
   pr2_controllers_msgs::JointTrajectoryControllerState joint_controller_state;
+#else
+  control_msgs::JointTrajectoryControllerState joint_controller_state;
+#endif
   joint_controller_state.header.stamp = tm_on_execute;
 
   control_msgs::FollowJointTrajectoryFeedback follow_joint_trajectory_feedback;
@@ -463,12 +484,14 @@ RTC::ReturnCode_t HrpsysSeqStateROSBridge::onExecute(RTC::UniqueId ec_id)
     }
     updateSensorTransform(sensor_tf_stamp); // transform depends on joint angles, not sensor values
 
+#ifdef USE_PR2_CONTROLLERS_MSGS
     if ( joint_trajectory_server.isActive() &&
 	 interpolationp == true &&  m_service0->isEmpty() == true ) {
       pr2_controllers_msgs::JointTrajectoryResult result;
       joint_trajectory_server.setSucceeded(result);
       interpolationp = false;
     }
+#endif
     if ( follow_joint_trajectory_server.isActive() &&
 	 interpolationp == true &&  m_service0->isEmpty() == true ) {
       control_msgs::FollowJointTrajectoryResult result;
@@ -479,10 +502,12 @@ RTC::ReturnCode_t HrpsysSeqStateROSBridge::onExecute(RTC::UniqueId ec_id)
 
     ros::Time tm_on_execute = ros::Time::now();
 
+#ifdef USE_PR2_CONTROLLERS_MSGS
     if ( joint_trajectory_server.isActive() ) {
       pr2_controllers_msgs::JointTrajectoryFeedback joint_trajectory_feedback;
       joint_trajectory_server.publishFeedback(joint_trajectory_feedback);
     }
+#endif
     if ( follow_joint_trajectory_server.isActive() ) {
       follow_joint_trajectory_feedback.header.stamp = tm_on_execute;
       if (!follow_joint_trajectory_feedback.joint_names.empty() &&

--- a/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.h
+++ b/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.h
@@ -21,8 +21,12 @@
 #include "geometry_msgs/WrenchStamped.h"
 #include "actionlib/server/simple_action_server.h"
 #include "control_msgs/FollowJointTrajectoryAction.h"
+#ifdef USE_PR2_CONTROLLERS_MSGS
 #include "pr2_controllers_msgs/JointTrajectoryAction.h"
 #include "pr2_controllers_msgs/JointTrajectoryControllerState.h"
+#else
+#include "control_msgs/JointTrajectoryControllerState.h"
+#endif
 #include "dynamic_reconfigure/Reconfigure.h"
 #include "hrpsys_ros_bridge/MotorStates.h"
 #include "hrpsys_ros_bridge/ContactStatesStamped.h"
@@ -43,8 +47,10 @@ class HrpsysSeqStateROSBridge  : public HrpsysSeqStateROSBridgeImpl
   RTC::ReturnCode_t onExecute(RTC::UniqueId ec_id);
 
   void onJointTrajectory(trajectory_msgs::JointTrajectory trajectory);
+#ifdef USE_PR2_CONTROLLERS_MSGS
   void onJointTrajectoryActionGoal();
   void onJointTrajectoryActionPreempt();
+#endif
   void onFollowJointTrajectoryActionGoal();
   void onFollowJointTrajectoryActionPreempt();
   void onTrajectoryCommandCB(const trajectory_msgs::JointTrajectoryConstPtr& msg);
@@ -57,7 +63,9 @@ class HrpsysSeqStateROSBridge  : public HrpsysSeqStateROSBridgeImpl
   ros::Publisher joint_state_pub, joint_controller_state_pub, mot_states_pub, diagnostics_pub, clock_pub, zmp_pub, ref_cp_pub, act_cp_pub, odom_pub, imu_pub, em_mode_pub, ref_contact_states_pub, act_contact_states_pub;
   ros::Subscriber trajectory_command_sub;
   std::vector<ros::Publisher> fsensor_pub, cop_pub;
+#ifdef USE_PR2_CONTROLLERS_MSGS
   actionlib::SimpleActionServer<pr2_controllers_msgs::JointTrajectoryAction> joint_trajectory_server;
+#endif
   actionlib::SimpleActionServer<control_msgs::FollowJointTrajectoryAction> follow_joint_trajectory_server;
   ros::ServiceServer sendmsg_srv;
   ros::ServiceServer set_sensor_transformation_srv;

--- a/hrpsys_ros_bridge/src/hrpsys_ros_bridge/hrpsys_dashboard.py
+++ b/hrpsys_ros_bridge/src/hrpsys_ros_bridge/hrpsys_dashboard.py
@@ -30,8 +30,13 @@ from rqt_robot_dashboard.widgets import MenuDashWidget
 
 from python_qt_binding.QtCore import QSize
 from python_qt_binding.QtCore import Qt
-from python_qt_binding.QtGui import (QMessageBox, QSplashScreen,
-                                     QPixmap, QApplication)
+try: # 14.04
+    from python_qt_binding.QtGui import (QMessageBox, QSplashScreen,
+                                         QPixmap, QApplication)
+except: # 16.04
+    from python_qt_binding.QtWidgets import (QMessageBox, QSplashScreen,
+                                             QApplication)
+    from python_qt_binding.QtGui import QPixmap
 
 from subprocess import check_call, Popen
 

--- a/hrpsys_ros_bridge/test/test-samplerobot-hcf.launch
+++ b/hrpsys_ros_bridge/test/test-samplerobot-hcf.launch
@@ -11,6 +11,6 @@
 
   <node name="hrpsys_seq_state_ros_bridge_tf_relay" pkg="hrpsys_ros_bridge" type="hrpsys_seq_state_ros_bridge_tf_relay_for_test.py"/>
 
-  <test test-name="samplerobot_hcf" pkg="hrpsys_ros_bridge" type="test-samplerobot-hcf.py" retry="4" time-limit="300" args="-ORBInitRef NameService=corbaloc:iiop:localhost:2809/NameService"/>
+  <test test-name="samplerobot_hcf" pkg="hrpsys_ros_bridge" type="test-samplerobot-hcf.py" retry="4" time-limit="600" args="-ORBInitRef NameService=corbaloc:iiop:localhost:2809/NameService"/>
 
 </launch>

--- a/hrpsys_tools/test/test-pa10.test
+++ b/hrpsys_tools/test/test-pa10.test
@@ -13,9 +13,9 @@
      -->
   </include>
 
-  <!-- need time.sleep(1): need code that waht for all component in serialization is actually activated.... -->
+  <!-- need time.sleep(1): need this code for waiting for all component in serialization is actually activated.... -->
   <test test-name="hrpsys_tool_config_interactive" pkg="hrpsys_tools"
-        type="hrpsys_tools_config.py" args='--host 127.0.0.1 --port 2809 -i PA10Controller\(Robot\)0 -c "import rostest, unittest" "import time" "time.sleep(5)" "hcf.setJointAngles([10,10,10,10,10,10,10,10,10], 1)" "print hcf.getJointAngles()" "rostest.rosrun(\"hrpsys_tools\", \"test_interactive\", unittest.TestCase)" "quit()"'
+        type="hrpsys_tools_config.py" args='--host 127.0.0.1 --port 2809 -i PA10Controller\(Robot\)0 -c "import rostest, unittest" "import time" "time.sleep(10)" "hcf.setJointAngles([10,10,10,10,10,10,10,10,10], 1)" "print hcf.getJointAngles()" "rostest.rosrun(\"hrpsys_tools\", \"test_interactive\", unittest.TestCase)" "quit()"'
         retry="4" />
 
 </launch>

--- a/openrtm_tools/test/test-rtmlaunch.test
+++ b/openrtm_tools/test/test-rtmlaunch.test
@@ -28,5 +28,5 @@
   <rtconnect from="SequenceInComponent0.rtc:FloatSeq"  to="SequenceOutComponent0.rtc:FloatSeq" subscription_type="flush"/>
   <!-- END:openrtm connection -->
 
-  <test test-name="rtmlaunch" pkg="openrtm_tools" type="test-rtmlaunch.py" />
+  <test test-name="rtmlaunch" pkg="openrtm_tools" type="test-rtmlaunch.py" retry="4" />
 </launch>

--- a/rtmbuild/test/test-compile-idl.test
+++ b/rtmbuild/test/test-compile-idl.test
@@ -7,6 +7,6 @@
   <node name="provider" pkg="openrtm_aist" type="MyServiceProviderComp" args='$(arg openrtm_args)' />
   <node name="consumer" pkg="openrtm_aist" type="MyServiceConsumerComp"	args='$(arg openrtm_args)' />
 
-  <test test-name="test_compile_idl_sh" pkg="rtmbuild" type="test-compile-idl.sh" />
+  <test test-name="test_compile_idl_sh" pkg="rtmbuild" type="test-compile-idl.sh" retry="4" time-limit="120" />
 
 </launch>


### PR DESCRIPTION
- use jsk_travis 0.4.28
- test/{test-samplerobot.py,test-pa10.py} support both pr2_controllers_msgs and controllr_msgs
- src/hrpsys_ros_bridge/hrpsys_dashboard.py: fix for qt5
- .travis.yml: enable ROS_DISTRO=kinetic as default
- add USE_PR2_CONTROLLERS_MSGS definition
- CMakeLists.txt : we do not use pr2_msgs on build time
- CMakeLists.txt : remove code to download wet pr2_controllers_msgs for groovy