### PR TITLE
Update OTD reference force/moment estimation codes

### DIFF
--- a/hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l
+++ b/hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l
@@ -855,7 +855,8 @@
      (let ((ret (send self :ObjectContactTurnaroundDetectorService_getObjectForcesMoments)))
        (list (split-vector (send (send ret :o_forces) :data))
              (split-vector (send (send ret :o_moments) :data))
-             (send ret :o_3dofwrench))
+             (send ret :o_3dofwrench)
+             (send ret :o_fric_coeff_wrench))
        ))
    )
   (:set-object-turnaround-ref-force
@@ -904,15 +905,16 @@
         (unix:usleep (* 1000 periodic-time))
         (setq detector-mode (send self :check-object-turnaround-detection))
         (setq fm-ret (send self :get-otd-object-forces-moments))
-        (format t ";;   Detecting... (detector-mode = ~A, limbs = ~A, current forces = ~A[N], current moments = ~A[Nm], current res force = ~A[N])~%"
+        (format t ";;   Detecting... (detector-mode = ~A, limbs = ~A, forces = ~A[N], moments = ~A[Nm], res force = ~A[N], fric force = ~A[N])~%"
                 detector-mode limbs
-                (car fm-ret) (cadr fm-ret) (caddr fm-ret))
+                (car fm-ret) (cadr fm-ret) (caddr fm-ret) (cadddr fm-ret))
         )
        ;; Step.3 If detected, update ref force
        (if (eq detector-mode :mode_detected)
            (progn
-             (format t ";; Detected (limbs = ~A, forces = ~A[N], moments = ~A[Nm], res-force = ~A[N])~%"
-                     limbs (car fm-ret) (cadr fm-ret) (caddr fm-ret))
+             (format t ";; Detected (limbs = ~A, forces = ~A[N], moments = ~A[Nm], res force = ~A[N], fric force = ~A[N])~%"
+                     limbs
+                     (car fm-ret) (cadr fm-ret) (caddr fm-ret) (cadddr fm-ret))
              (if set-ref-force-p
                  (send self :set-ref-forces
                        (mapcar #'(lambda (org-f limb)
@@ -979,12 +981,16 @@
         (unix:usleep (* 1000 periodic-time))
         (setq detector-mode (send self :check-object-turnaround-detection))
         (Setq fm-ret (send self :get-otd-object-forces-moments))
-        (format t ";;   Detecting... (detector-mode = ~A, current force moment = ~A)~%" detector-mode fm-ret)
+        (format t ";;   Detecting... (detector-mode = ~A, limbs = ~A, forces = ~A[N], moments = ~A[Nm], res moment = ~A[Nm], fric force = ~A[N])~%"
+                detector-mode limbs
+                (car fm-ret) (cadr fm-ret) (caddr fm-ret) (cadddr fm-ret))
         )
        (if (eq detector-mode :mode_detected)
            (let* ((total-moment (caddr fm-ret))
                   (forces-from-total-moment (funcall func (v. axis total-moment))))
-             (format t ";; Detected (force moment = ~A ~A)~%" fm-ret forces-from-total-moment)
+             (format t ";; Detected (limbs = ~A, forces from total moment = ~A[N], forces = ~A[N], moments = ~A[Nm], res moment = ~A[Nm], fric force = ~A[N])~%"
+                     limbs forces-from-total-moment
+                     (car fm-ret) (cadr fm-ret) (caddr fm-ret) (cadddr fm-ret))
              (if set-ref-force-p
                  (send self :set-ref-forces
                        (mapcar #'(lambda (limb)

--- a/hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l
+++ b/hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l
@@ -823,7 +823,7 @@
 
 ;; ObjectContactTurnaroundDetector
 (def-set-get-param-method 'hrpsys_ros_bridge::OpenHRP_ObjectContactTurnaroundDetectorService_objectContactTurnaroundDetectorParam
-  :set-object-turnaround-detector-param :get-object-turnaround-detector-param :get-object-turnaround-detector-param-arguments
+  :raw-set-object-turnaround-detector-param :get-object-turnaround-detector-param :get-object-turnaround-detector-param-arguments
   :ObjectContactTurnaroundDetectorService_setObjectContactTurnaroundDetectorParam
   :ObjectContactTurnaroundDetectorService_getObjectContactTurnaroundDetectorParam)
 (defmethod rtm-ros-robot-interface
@@ -1007,6 +1007,30 @@
        (if (eq detector-mode :mode_detected)
            otd-ret-wrenches)
        )))
+  (:set-object-turnaround-detector-param
+   (&rest args
+    &key detector-total-wrench
+    &allow-other-keys)
+   "Set Object Turnaround Detector.
+    For arguments, please see (send *ri* :get-object-turnaround-detector-param-arguments)."
+   (let ((prm (send self :get-object-turnaround-detector-param)))
+     (send* self :raw-set-object-turnaround-detector-param
+            (append
+             (if (memq :detector-total-wrench args)
+                 (list :detector-total-wrench
+                       (if (or (null detector-total-wrench) (integerp detector-total-wrench))
+                           detector-total-wrench
+                         (let ((dtw (read-from-string (format nil "HRPSYS_ROS_BRIDGE::OPENHRP_OBJECTCONTACTTURNAROUNDDETECTORSERVICE_DETECTORTOTALWRENCH::*~A*" (substitute (elt "_" 0) (elt "-" 0) (string-downcase detector-total-wrench))))))
+                           (if (boundp dtw)
+                               (eval dtw)
+                             (error ";; no such :detector-total-wrench ~A in :set-object-turnaround-detector-param~%" detector-total-wrench))))))
+             args))))
+  (:get-object-turnaround-detector-detector-total-wrench
+   ()
+   "Get Object Turnadound Detector as Euslisp symbol."
+   (send self :get-idl-enum-values
+         (send (send self :get-object-turnaround-detector-param) :detector_total_wrench)
+         "HRPSYS_ROS_BRIDGE::OPENHRP_OBJECTCONTACTTURNAROUNDDETECTORSERVICE_DETECTORTOTALWRENCH"))
   )
 
 ;; RemoveForceSensorLinkOffset

--- a/hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l
+++ b/hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l
@@ -879,7 +879,10 @@
     detect-time-offset is additional checking time [msec].
     set-ref-force-time is time to set reference force [msec].
     If set-ref-force-p is t, set estimated reference force. Otherwise, set reference force to zero.
-    periodic-time is loop wait time[msec]."
+    periodic-time is loop wait time[msec].
+    return-value-mode is used to select return value type.
+    If :all, returns the results of :get-otd-object-forces-moments itself. If :forces, returns forces results.
+    If set-ref-force-linear-p t, set linear interpolation first and set hoffarbib interpolation in return."
    ;; Step.0 Initialize
    (format t ";; Start object turnaround detection~%")
    (send self :set-object-turnaround-detector-param :axis axis :detector-total-wrench detector-total-wrench)
@@ -967,7 +970,10 @@
     detect-time-offset is additional checking time [msec].
     set-ref-force-time is time to set reference force [msec].
     If set-ref-force-p is t, set estimated reference force. Otherwise, set reference force to zero.
-    periodic-time is loop wait time[msec]."
+    periodic-time is loop wait time[msec].
+    return-value-mode is used to select return value type.
+    If :all, returns the results of :get-otd-object-forces-moments itself. If :forces, returns forces results.
+    If set-ref-force-linear-p t, set linear interpolation first and set hoffarbib interpolation in return."
    (format t ";; Start object turnaround detection~%")
    (let ((all-limbs (sort '(:rleg :lleg :rarm :larm) #'< #'(lambda (x) (position (car (send robot x :force-sensors)) (send robot :force-sensors)))))
          (fs-list (funcall func max-ref-moment)))

--- a/hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l
+++ b/hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l
@@ -900,16 +900,16 @@
        ;; Step.2 Detection loop
        (do-until-key-with-check
         (not (not (memq detector-mode '(:mode_started :mode_detector_idle))))
+        (unix:usleep (* 1000 periodic-time))
         (setq detector-mode (send self :check-object-turnaround-detection))
         (setq fm-ret (send self :get-otd-object-forces-moments))
         (format t ";;   Detecting... (detector-mode = ~A, limbs = ~A, current forces = ~A[N], current moments = ~A[Nm], current res force = ~A[N])~%"
                 detector-mode limbs
                 (car fm-ret) (cadr fm-ret) (caddr fm-ret))
-        (unix:usleep (* 1000 periodic-time)))
+        )
        ;; Step.3 If detected, update ref force
        (if (eq detector-mode :mode_detected)
            (progn
-             (setq fm-ret (send self :get-otd-object-forces-moments))
              (format t ";; Detected (limbs = ~A, forces = ~A[N], moments = ~A[Nm], res-force = ~A[N])~%"
                      limbs (car fm-ret) (cadr fm-ret) (caddr fm-ret))
              (if set-ref-force-p

--- a/hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l
+++ b/hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l
@@ -870,6 +870,7 @@
          (periodic-time 200) ;; [msec]
          (detector-total-wrench :total-force)
          (return-value-mode :forces)
+         (set-ref-force-linear-p)
          )
    "Set object turnaround reference force.
     axis is resultant force direction.
@@ -887,6 +888,7 @@
           (org-ref-forces (mapcar #'(lambda (limb) (send self :reference-force-vector limb)) all-limbs))
           (diff-force (scale (/ max-ref-force (length limbs)) axis)))
      ;; Step.1 Set ref force and start detection
+     (if set-ref-force-linear-p (send self :set-interpolation-mode :linear))
      (send self :set-ref-forces
            (mapcar #'(lambda (org-f limb)
                        (if (memq limb limbs)
@@ -935,6 +937,7 @@
            )
          )
        (send self :wait-interpolation-seq)
+       (if set-ref-force-linear-p (send self :set-interpolation-mode :hoffarbib))
        (if (eq detector-mode :mode_detected)
            (case return-value-mode
                  (:all fm-ret)
@@ -954,6 +957,7 @@
          (periodic-time 200) ;; [msec]
          (detector-total-wrench :total-moment)
          (return-value-mode :all)
+         (set-ref-force-linear-p)
          )
    "Set object turnaround reference force.
     axis is axis which resultant moment is around.
@@ -969,6 +973,7 @@
          (fs-list (funcall func max-ref-moment)))
      (send self :set-object-turnaround-detector-param
            :axis axis :moment-center (scale 1e-3 moment-center) :detector-total-wrench detector-total-wrench)
+     (if set-ref-force-linear-p (send self :set-interpolation-mode :linear))
      (send self :set-ref-forces
            (mapcar #'(lambda (limb)
                        (if (memq limb '(:rleg :lleg))
@@ -1017,6 +1022,7 @@
            )
          )
        (send self :wait-interpolation-seq)
+       (if set-ref-force-linear-p (send self :set-interpolation-mode :hoffarbib))
        (if (eq detector-mode :mode_detected)
            (case return-value-mode
                  (:all fm-ret)

--- a/hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l
+++ b/hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l
@@ -867,6 +867,7 @@
          (set-ref-force-time 2000.0)
          (set-ref-force-p t)
          (periodic-time 200) ;; [msec]
+         (detector-total-wrench :total-force)
          )
    "Set object turnaround reference force.
     axis is resultant force direction.
@@ -878,7 +879,7 @@
     periodic-time is loop wait time[msec]."
    ;; Step.0 Initialize
    (format t ";; Start object turnaround detection~%")
-   (send self :set-object-turnaround-detector-param :axis axis :detector-total-wrench 0)
+   (send self :set-object-turnaround-detector-param :axis axis :detector-total-wrench detector-total-wrench)
    (send self :state)
    (let* ((all-limbs (sort '(:rleg :lleg :rarm :larm) #'< #'(lambda (x) (position (car (send robot x :force-sensors)) (send robot :force-sensors)))))
           (org-ref-forces (mapcar #'(lambda (limb) (send self :reference-force-vector limb)) all-limbs))
@@ -945,6 +946,7 @@
          (set-ref-force-time 2000.0)
          (set-ref-force-p t)
          (periodic-time 200) ;; [msec]
+         (detector-total-wrench :total-moment)
          )
    "Set object turnaround reference force.
     axis is axis which resultant moment is around.
@@ -959,7 +961,7 @@
    (let ((all-limbs (sort '(:rleg :lleg :rarm :larm) #'< #'(lambda (x) (position (car (send robot x :force-sensors)) (send robot :force-sensors)))))
          (fs-list (funcall func max-ref-moment)))
      (send self :set-object-turnaround-detector-param
-           :axis axis :moment-center (scale 1e-3 moment-center) :detector-total-wrench 1)
+           :axis axis :moment-center (scale 1e-3 moment-center) :detector-total-wrench detector-total-wrench)
      (send self :set-ref-forces
            (mapcar #'(lambda (limb)
                        (if (memq limb '(:rleg :lleg))

--- a/hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l
+++ b/hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l
@@ -973,24 +973,24 @@
            :ref-diff-wrench max-ref-moment
            :max-time (* 1e-3 (+ detect-time-offset max-time))
            :limbs limbs)
-     (let ((detector-mode :mode_detector_idle) (fm-ret) (otd-ret-wrenches))
+     (let ((detector-mode :mode_detector_idle) (fm-ret))
        (do-until-key-with-check
         (not (not (memq detector-mode '(:mode_started :mode_detector_idle))))
+        (unix:usleep (* 1000 periodic-time))
         (setq detector-mode (send self :check-object-turnaround-detection))
-        (format t ";;   Detecting... (detector-mode = ~A, current force moment = ~A)~%" detector-mode (send self :get-otd-object-forces-moments))
-        (unix:usleep (* 1000 periodic-time)))
+        (Setq fm-ret (send self :get-otd-object-forces-moments))
+        (format t ";;   Detecting... (detector-mode = ~A, current force moment = ~A)~%" detector-mode fm-ret)
+        )
        (if (eq detector-mode :mode_detected)
-           (progn
-             (Setq otd-ret-wrenches (send self :get-otd-object-forces-moments))
-             (setq fm-ret (caddr otd-ret-wrenches))
-             (format t ";; Detected (force moment = ~A ~A)~%" fm-ret (funcall func (v. axis fm-ret)))
-             (setq fm-ret (funcall func (v. axis fm-ret)))
+           (let* ((total-moment (caddr fm-ret))
+                  (forces-from-total-moment (funcall func (v. axis total-moment))))
+             (format t ";; Detected (force moment = ~A ~A)~%" fm-ret forces-from-total-moment)
              (if set-ref-force-p
                  (send self :set-ref-forces
                        (mapcar #'(lambda (limb)
                                    (if (memq limb '(:rleg :lleg))
                                        (float-vector 0 0 0)
-                                     (elt fm-ret (position limb limbs))))
+                                     (elt forces-from-total-moment (position limb limbs))))
                                all-limbs)
                        set-ref-force-time)
                (send self :set-ref-force
@@ -1007,7 +1007,7 @@
          )
        (send self :wait-interpolation-seq)
        (if (eq detector-mode :mode_detected)
-           otd-ret-wrenches)
+           fm-ret)
        )))
   (:set-object-turnaround-detector-param
    (&rest args

--- a/hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l
+++ b/hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l
@@ -869,6 +869,7 @@
          (set-ref-force-p t)
          (periodic-time 200) ;; [msec]
          (detector-total-wrench :total-force)
+         (return-value-mode :forces)
          )
    "Set object turnaround reference force.
     axis is resultant force direction.
@@ -935,7 +936,10 @@
          )
        (send self :wait-interpolation-seq)
        (if (eq detector-mode :mode_detected)
-           (car fm-ret))
+           (case return-value-mode
+                 (:all fm-ret)
+                 (:forces (car fm-ret))
+                 (t nil)))
        )))
   (:set-object-turnaround-ref-moment
    (&key (limbs '(:rarm :larm))
@@ -949,6 +953,7 @@
          (set-ref-force-p t)
          (periodic-time 200) ;; [msec]
          (detector-total-wrench :total-moment)
+         (return-value-mode :all)
          )
    "Set object turnaround reference force.
     axis is axis which resultant moment is around.
@@ -975,7 +980,7 @@
            :ref-diff-wrench max-ref-moment
            :max-time (* 1e-3 (+ detect-time-offset max-time))
            :limbs limbs)
-     (let ((detector-mode :mode_detector_idle) (fm-ret))
+     (let ((detector-mode :mode_detector_idle) (fm-ret) (forces-from-total-moment))
        (do-until-key-with-check
         (not (not (memq detector-mode '(:mode_started :mode_detector_idle))))
         (unix:usleep (* 1000 periodic-time))
@@ -986,8 +991,8 @@
                 (car fm-ret) (cadr fm-ret) (caddr fm-ret) (cadddr fm-ret))
         )
        (if (eq detector-mode :mode_detected)
-           (let* ((total-moment (caddr fm-ret))
-                  (forces-from-total-moment (funcall func (v. axis total-moment))))
+           (let ((total-moment (caddr fm-ret)))
+             (setq forces-from-total-moment (funcall func (v. axis total-moment)))
              (format t ";; Detected (limbs = ~A, forces from total moment = ~A[N], forces = ~A[N], moments = ~A[Nm], res moment = ~A[Nm], fric force = ~A[N])~%"
                      limbs forces-from-total-moment
                      (car fm-ret) (cadr fm-ret) (caddr fm-ret) (cadddr fm-ret))
@@ -1013,7 +1018,11 @@
          )
        (send self :wait-interpolation-seq)
        (if (eq detector-mode :mode_detected)
-           fm-ret)
+           (case return-value-mode
+                 (:all fm-ret)
+                 (:forces (car fm-ret))
+                 (:forces-from-total-moment forces-from-total-moment)
+                 (t nil)))
        )))
   (:set-object-turnaround-detector-param
    (&rest args


### PR DESCRIPTION
Update OTD reference force/moment estimation codes
- Fix sleep position and get status positions.
- Add set linear interpolation before estimation (disabled by default)
- Add more return values
- Support friction coeffient values
- etc...
