### PR TITLE
Add method to print RTCs' parameters in more readable style using *print-object*.

### DIFF
--- a/hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l
+++ b/hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l
@@ -2098,6 +2098,44 @@
     ))
   )
 
+(defmethod rtm-ros-robot-interface
+  (:print-rtc-param-all
+   ()
+   "Print RTC parameter struct probided by :get-xx method in more readable style for all recommended RTCs.
+    Check all possible RTCs by checking existence of ROSBridge nodes."
+   (let ((rosbridge-nodes (ros::get-nodes)))
+     (when (find "/AutoBalancerServiceROSBridge" rosbridge-nodes :test #'string=)
+       (format t ";; :get-gait-generator-param~%")
+       (print-ros-msg (send self :get-gait-generator-param))
+       (format t ";; :get-auto-balancer-param~%")
+       (print-ros-msg (send self :get-auto-balancer-param)))
+     (when (find "/StabilizerServiceROSBridge" rosbridge-nodes :test #'string=)
+       (format t ";; :get-st-param~%")
+       (print-ros-msg (send self :get-st-param)))
+     (when (find "/ObjectContactTurnaroundDetectorServiceROSBridge" rosbridge-nodes :test #'string=)
+       (format t ";; :get-object-turnaround-detector-param~%")
+       (print-ros-msg (send self :get-object-turnaround-detector-param)))
+     (when (find "/KalmanFilterServiceROSBridge" rosbridge-nodes :test #'string=)
+       (format t ";; :get-kalman-filter-param~%")
+       (print-ros-msg (send self :get-kalman-filter-param)))
+     (when (find "/ReferenceForceUpdaterServiceROSBridge" rosbridge-nodes :test #'string=)
+       (dolist (limb (sort '(:rleg :lleg :rarm :larm) #'< #'(lambda (x) (position (car (send robot x :force-sensors)) (send robot :force-sensors)))))
+         (format t ";; :get-reference-force-updater-param ~A~%" limb)
+         (print-ros-msg (send self :get-reference-force-updater-param limb))))
+     (when (find "/ImpedanceControllerServiceROSBridge" rosbridge-nodes :test #'string=)
+       (dolist (limb (sort '(:rleg :lleg :rarm :larm) #'< #'(lambda (x) (position (car (send robot x :force-sensors)) (send robot :force-sensors)))))
+         (format t ";; :get-impedance-controller-param ~A~%" limb)
+         (print-ros-msg (send self :get-impedance-controller-param limb))))
+     (when (find "/RemoveForceSensorLinkOffsetServiceROSBridge" rosbridge-nodes :test #'string=)
+       (dolist (limb (sort '(:rleg :lleg :rarm :larm) #'< #'(lambda (x) (position (car (send robot x :force-sensors)) (send robot :force-sensors)))))
+         (format t ";; :get-forcemoment-offset-param ~A~%" limb)
+         (print-ros-msg (send self :get-forcemoment-offset-param limb))))
+     (when (find "/TorqueControllerServiceROSBridge" rosbridge-nodes :test #'string=)
+       (dolist (j (send robot :joint-list))
+         (format t ";; :get-torque-controller-param ~A~%" (read-from-string (format nil ":~A" (send j :name))))
+         (print-ros-msg (send self :get-torque-controller-param (read-from-string (format nil ":~A" (send j :name)))))))
+     t))
+  )
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
Add method to print RTCs' parameters in more readable style using `*print-object*`.
This is required for debugging.

Without this PR (not readable)
```
17.irteusgl$ (send *ri* :get-auto-balancer-param)
#<hrpsys_ros_bridge::openhrp_autobalancerservice_autobalancerparam #X6c4eb08>
6.irteusgl$ (send *ri* :get-impedance-controller-param :rarm)
#<hrpsys_ros_bridge::openhrp_impedancecontrollerservice_impedanceparam #X69d87e8>
```

With this PR (slots variables are readable because of `:slots` method and `*print-object*` global variable)
```
18.irteusgl$ (send *ri* :print-rtc-param :get-auto-balancer-param)
;; Print param from (send *ri* :get-auto-balancer-param)
((plist)
 (ros::_default_zmp_offsets . #J(std_msgs::float64multiarray nil #J(std_msgs::multiarraylayout nil (#J(std_msgs::multiarraydimension nil "" 4 16) #J(std_msgs::multiarraydimension nil "" 3 3)) 0) #f(0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.\
0 0.0 0.0 0.0)))
 (ros::_move_base_gain . 0.8)
 (ros::_controller_mode . 1)
 (ros::_use_force_mode . 1)
 (ros::_graspless_manip_mode)
 (ros::_graspless_manip_arm . "arms")
 (ros::_graspless_manip_p_gain . #f(0.0 0.0 0.0))
 (ros::_graspless_manip_reference_trans_pos . #f(0.0 0.0 0.0))
 (ros::_graspless_manip_reference_trans_rot
  . #f(1.0 0.0 0.0 0.0))
 (ros::_transition_time . 2.0)
 (ros::_zmp_transition_time . 1.0)
 (ros::_adjust_footstep_transition_time . 2.0)
 (ros::_leg_names "rleg" "lleg")
 (ros::_has_ik_failed)
 (ros::_pos_ik_thre . 0.0005)
 (ros::_rot_ik_thre . 0.000175)
 (ros::_is_hand_fix_mode)
 (ros::_end_effector_list
  #J(hrpsys_ros_bridge::openhrp_autobalancerservice_footstep nil #f(0.0 0.01 -0.065) #f(0.707105 0.0 0.707108 0.0) "larm")
  #J(hrpsys_ros_bridge::openhrp_autobalancerservice_footstep nil #f(0.0 0.0 -0.07) #f(1.0 0.0 0.0 0.0) "lleg")
  #J(hrpsys_ros_bridge::openhrp_autobalancerservice_footstep nil #f(0.0 -0.01 -0.065) #f(0.707105 0.0 0.707108 0.0) "rarm")
  #J(hrpsys_ros_bridge::openhrp_autobalancerservice_footstep nil #f(0.0 0.0 -0.07) #f(1.0 0.0 0.0 0.0) "rleg"))
 (ros::_default_gait_type . 0)
 (ros::_ik_limb_parameters
  #J(hrpsys_ros_bridge::openhrp_autobalancerservice_iklimbparameters nil #f(1.0 1.0 1.0 1.0 1.0 1.0) 1.0 0.001 0.01 0.1)
  #J(hrpsys_ros_bridge::openhrp_autobalancerservice_iklimbparameters nil #f(1.0 1.0 1.0 1.0 1.0 1.0) 1.0 0.001 0.01 0.1)
  #J(hrpsys_ros_bridge::openhrp_autobalancerservice_iklimbparameters nil #f(1.0 1.0 1.0 1.0 1.0 1.0 1.0) 1.0 0.001 0.01 0.1)
  #J(hrpsys_ros_bridge::openhrp_autobalancerservice_iklimbparameters nil #f(1.0 1.0 1.0 1.0 1.0 1.0 1.0) 1.0 0.001 0.01 0.1))
 (ros::_use_limb_stretch_avoidance)
 (ros::_limb_stretch_avoidance_time_const . 1.5)
 (ros::_limb_stretch_avoidance_vlimit . #f(-0.002 1.000000e-04))
 (ros::_limb_length_margin . #f(0.02 0.02 0.02 0.02))
 (ros::_additional_force_applied_link_name . "WAIST")
 (ros::_additional_force_applied_point_offset . #f(0.0 0.0 0.0)))
8.irteusgl$ (send *ri* :print-rtc-param :get-impedance-controller-param :rarm)
;; Print param from (send *ri* :get-impedance-controller-param :rarm)
((plist)
 (ros::_m_p . 5.0)
 (ros::_d_p . 420.0)
 (ros::_k_p . 200.0)
 (ros::_m_r . 5.0)
 (ros::_d_r . 100000.0)
 (ros::_k_r . 100000.0)
 (ros::_force_gain . #f(1.0 1.0 1.0))
 (ros::_moment_gain . #f(1.0 1.0 1.0))
 (ros::_sr_gain . 1.0)
 (ros::_avoid_gain . 0.001)
 (ros::_reference_gain . 0.01)
 (ros::_manipulability_limit . 0.1)
 (ros::_controller_mode . 1)
 (ros::_ik_optional_weight_vector
  . #f(1.0 1.0 1.0 1.0 1.0 1.0 1.0))
 (ros::_use_sh_base_pos_rpy))
```

With this PR (advanced usage)
```
;; Choose pprint or not.
:: Set file stream.
12.irteusgl$ (with-open-file (ff "/tmp/hoge" :direction :output) (send *ri* :print-rtc-param :get-kalman-filter-param nil :use-pprint-p nil :file-stream ff))
t
13.irteusgl$ (with-open-file (ff "/tmp/hoge" :direction :input) (read ff))
#<hrpsys_ros_bridge::openhrp_kalmanfilterservice_kalmanfilterparam #X71f7670>

;; Print all possible RTCs, such as st, impedance, ...
irteusgl$ (send *ri* :print-rtc-param-all)
....