### PR TITLE
【rtm-ros-robot-interface.l】add method :set-ref-force-moment to rtm-ros-robot-interface class

### DIFF
--- a/hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l
+++ b/hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l
@@ -500,6 +500,26 @@
    (if update-robot-state (send self :state))
    (send self :set-ref-forces-moments (send self :reference-force-vector) moment-list tm)
    )
+  (:set-ref-force-moment
+   (force moment tm &optional (limb :arms) &key (update-robot-state t))
+   "Set reference force [N] and moment [Nm]. tm is interpolation time [ms].
+    limb should be limb symbol name such as :rarm, :larm, :rleg, :lleg, :arms, or :legs."
+   (if update-robot-state (send self :state))
+   (let ((limbs (case limb
+		  (:arms (list :rarm :larm))
+		  (:legs (list :rleg :lleg))
+		  (t (list limb)))))
+     (send self :set-ref-forces-moments
+           (mapcar #'(lambda (fs rfv)
+                       (if (find-if #'(lambda (l) (equal fs (car (send robot l :force-sensors)))) limbs)
+                           force rfv))
+                   (send robot :force-sensors) (send self :reference-force-vector))
+	   (mapcar #'(lambda (fs rfv)
+                       (if (find-if #'(lambda (l) (equal fs (car (send robot l :force-sensors)))) limbs)
+                           moment rfv))
+                   (send robot :force-sensors) (send self :reference-moment-vector))
+           tm)
+     ))
   (:set-ref-force
    (force tm &optional (limb :arms) &key (update-robot-state t))
    "Set reference force [N]. tm is interpolation time [ms].

--- a/hrpsys_ros_bridge/test/hrpsys-samples/samplerobot-impedance-controller.l
+++ b/hrpsys_ros_bridge/test/hrpsys-samples/samplerobot-impedance-controller.l
@@ -36,6 +36,12 @@
   (send *ri* :wait-interpolation-seq)
   (send *ri* :set-ref-moment (float-vector 0 0 0) 2000 :rarm)
   (send *ri* :wait-interpolation-seq)
+  (send *ri* :set-ref-force-moment
+        (float-vector 10 10 -10) (float-vector 0.2 0.2 -0.5) 2000 :rarm)
+  (send *ri* :wait-interpolation-seq)
+  (send *ri* :set-ref-force-moment
+        (float-vector 0 0 0) (float-vector 0 0 0) 2000 :rarm)
+  (send *ri* :wait-interpolation-seq)
   t)
 
 (defun samplerobot-impedance-controller-demo3 ()


### PR DESCRIPTION
rtm-ros-robot-interfaceクラスのメソッドに、
:set-ref-forces-moments
:set-ref-forces
:set-ref-moments
と、これらのlimb指定バージョンの
:set-ref-force
:set-ref-moment
がありますが、
:set-ref-force-moment
のみ存在しなかったため、追加しました。