### PR TITLE
fix def-set-get-param-method in rtm-ros-robot-interface.l

### DIFF
--- a/hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l
+++ b/hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l
@@ -329,7 +329,7 @@
         (debug nil))
   (when (boundp param-class)
     (let* ((param-slots-list ;; get slots list for param-class
-            (remove-if #'(lambda (x) (string= "plist" x))
+            (remove-if #'(lambda (x) (or (string= "plist" x) (string= "connection-header")))
                        (mapcar #'(lambda (x) (string-left-trim "::_" (string-left-trim "ros" (format nil "~A" x))))
                                (concatenate cons (send (eval param-class) :slots)))))
            (param-name

--- a/hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l
+++ b/hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l
@@ -329,7 +329,7 @@
         (debug nil))
   (when (boundp param-class)
     (let* ((param-slots-list ;; get slots list for param-class
-            (remove-if #'(lambda (x) (or (string= "plist" x) (string= "connection-header")))
+            (remove-if #'(lambda (x) (or (string= "plist" x) (string= "connection-header" x)))
                        (mapcar #'(lambda (x) (string-left-trim "::_" (string-left-trim "ros" (format nil "~A" x))))
                                (concatenate cons (send (eval param-class) :slots)))))
            (param-name


### PR DESCRIPTION
Due to recent update in roseus (https://github.com/jsk-ros-pkg/jsk_roseus/commit/46affa0c0ce1a5c13de2c7d4011295c67a54f326), a new slot named "_connection-header" was added to ros::objects.
This change has caused an error when setting parameters of rtc components from roseus (e.g. :set-impedance-controller-param).
This is because slots were parsed when creating :set-...-param methods in rtm-ros-robot-interface.l by the function def-set-get-param-method. In this function, the slot of class like hrpsys_ros_bridge::OpenHRP_ImpedanceControllerService_impedanceParam was assumed to be like (plist, m_p, d_p, ...), but after the update in roseus, it was like (plist, connection-header, m_p, d_p, ...). Therefore, additional remove of "connection-header" is necessary for making :set-...-param method.
