### PR TITLE
Try to run multiple hrpsys simulation environments

### DIFF
--- a/hrpsys_ros_bridge/launch/collision_detector.launch
+++ b/hrpsys_ros_bridge/launch/collision_detector.launch
@@ -10,7 +10,7 @@
   <env name="SIMULATOR_NAME" value="$(arg SIMULATOR_NAME)" />
   <env name="RTCTREE_NAMESERVERS" value="$(arg nameserver):$(arg corbaport)" />
   
-  <arg name="omniorb_args" default="-ORBInitRef NameService=corbaloc:iiop:$(arg nameserver):$(arg corbaport)/NameService" />
+  <arg name="omniorb_args" default="-ORBInitRef NameService=corbaloc:iiop:$(arg nameserver):$(arg corbaport)/NameService -RTCManagerPort $(arg managerport)" />
   <arg name="openrtm_args" default='-o "corba.master_manager:$(arg nameserver):$(arg managerport)" -o "corba.nameservers:$(arg nameserver):$(arg corbaport)" -o "naming.formats:%n.rtc" -o "exec_cxt.periodic.type:PeriodicExecutionContext" -o "exec_cxt.periodic.rate:2000" -o "logger.file_name:/tmp/collision_detector%p.log"' />
   <arg name="MODEL_FILE" default="/opt/jsk/etc/HIRONX/model/main.wrl" />
   <arg name="CONF_FILE" />

--- a/hrpsys_ros_bridge/launch/collision_detector.launch
+++ b/hrpsys_ros_bridge/launch/collision_detector.launch
@@ -2,12 +2,16 @@
 <launch>
   <arg name="nameserver" default="localhost" />
   <arg name="corbaport" default="15005" />
+  <arg name="managerport" default="2810" />
+  <!-- <arg name="managerport" default="15006" /> -->
+  <!-- available in Kinetic -->
+  <!-- <arg name="managerport" default="$(eval arg('corbaport') + 1)"/> -->
   <arg name="SIMULATOR_NAME" default="RobotHardware0"/> <!-- please set $(arg ROBOT_NAME)(Robot) for simulation -->
   <env name="SIMULATOR_NAME" value="$(arg SIMULATOR_NAME)" />
   <env name="RTCTREE_NAMESERVERS" value="$(arg nameserver):$(arg corbaport)" />
   
   <arg name="omniorb_args" default="-ORBInitRef NameService=corbaloc:iiop:$(arg nameserver):$(arg corbaport)/NameService" />
-  <arg name="openrtm_args" default='-o "corba.nameservers:$(arg nameserver):$(arg corbaport)" -o "naming.formats:%n.rtc" -o "exec_cxt.periodic.type:PeriodicExecutionContext" -o "exec_cxt.periodic.rate:2000" -o "logger.file_name:/tmp/collision_detector%p.log"' />
+  <arg name="openrtm_args" default='-o "corba.master_manager:$(arg nameserver):$(arg managerport)" -o "corba.nameservers:$(arg nameserver):$(arg corbaport)" -o "naming.formats:%n.rtc" -o "exec_cxt.periodic.type:PeriodicExecutionContext" -o "exec_cxt.periodic.rate:2000" -o "logger.file_name:/tmp/collision_detector%p.log"' />
   <arg name="MODEL_FILE" default="/opt/jsk/etc/HIRONX/model/main.wrl" />
   <arg name="CONF_FILE" />
   <!-- <arg name="COLLISIONDETECTOR_INSTANCE_NAME" default="CollisionDetector0" /> -->

--- a/hrpsys_ros_bridge/launch/collision_detector.launch
+++ b/hrpsys_ros_bridge/launch/collision_detector.launch
@@ -9,8 +9,8 @@
   <arg name="SIMULATOR_NAME" default="RobotHardware0"/> <!-- please set $(arg ROBOT_NAME)(Robot) for simulation -->
   <env name="SIMULATOR_NAME" value="$(arg SIMULATOR_NAME)" />
   <env name="RTCTREE_NAMESERVERS" value="$(arg nameserver):$(arg corbaport)" />
-  
-  <arg name="omniorb_args" default="-ORBInitRef NameService=corbaloc:iiop:$(arg nameserver):$(arg corbaport)/NameService -RTCManagerPort $(arg managerport)" />
+  <!-- omniorb_args will be obsolete -->
+  <arg name="omniorb_args" default="-ORBInitRef NameService=corbaloc:iiop:$(arg nameserver):$(arg corbaport)/NameService" />
   <arg name="openrtm_args" default='-o "corba.master_manager:$(arg nameserver):$(arg managerport)" -o "corba.nameservers:$(arg nameserver):$(arg corbaport)" -o "naming.formats:%n.rtc" -o "exec_cxt.periodic.type:PeriodicExecutionContext" -o "exec_cxt.periodic.rate:2000" -o "logger.file_name:/tmp/collision_detector%p.log"' />
   <arg name="MODEL_FILE" default="/opt/jsk/etc/HIRONX/model/main.wrl" />
   <arg name="CONF_FILE" />
@@ -32,7 +32,7 @@
   <!-- launch collision result publisher -->
   <node pkg="hrpsys_ros_bridge" name="collision_state" type="collision_state.py"
         output="screen" if="$(arg RUN_COLLISION_STATE)"
-        args="$(arg MODEL_FILE) $(arg omniorb_args)" >
+        args="$(arg MODEL_FILE) $(arg openrtm_args) $(arg omniorb_args)" > <!-- omniorb_args is still used for backward compatibility -->
     <param name="comp_name" type="string" value="$(arg COLLISIONDETECTOR_INSTANCE_NAME)" />
   </node>
 </launch>

--- a/hrpsys_ros_bridge/launch/hrpsys_ros_bridge.launch
+++ b/hrpsys_ros_bridge/launch/hrpsys_ros_bridge.launch
@@ -44,7 +44,7 @@
   <!-- <arg name="managerport" default="$(eval arg('corbaport') + 1)"/> -->
   <arg name="periodic_rate" default="2000" />
   <env name="RTCTREE_NAMESERVERS" value="$(arg nameserver):$(arg corbaport)" />
-  <arg name="omniorb_args" default="-ORBInitRef NameService=corbaloc:iiop:$(arg nameserver):$(arg corbaport)/NameService" />
+  <arg name="omniorb_args" default="-ORBInitRef NameService=corbaloc:iiop:$(arg nameserver):$(arg corbaport)/NameService -RTCManagerPort $(arg managerport)" />
   <arg name="openrtm_args" default='-o "corba.master_manager:$(arg nameserver):$(arg managerport)" -o "corba.nameservers:$(arg nameserver):$(arg corbaport)" -o "naming.formats:%n.rtc" -o "exec_cxt.periodic.type:PeriodicExecutionContext" -o "exec_cxt.periodic.rate:$(arg periodic_rate)" -o "logger.file_name:/tmp/rtc%p.log"' />
   <arg name="subscription_type" default="new" />
   <arg name="push_policy" default="all" />

--- a/hrpsys_ros_bridge/launch/hrpsys_ros_bridge.launch
+++ b/hrpsys_ros_bridge/launch/hrpsys_ros_bridge.launch
@@ -38,10 +38,14 @@
   <!-- BEGIN:openrtm setting -->
   <arg name="nameserver" default="localhost" />
   <arg name="corbaport" default="15005" />
+  <arg name="managerport" default="2810" />
+  <!-- <arg name="managerport" default="15006" /> -->
+  <!-- available in Kinetic -->
+  <!-- <arg name="managerport" default="$(eval arg('corbaport') + 1)"/> -->
   <arg name="periodic_rate" default="2000" />
   <env name="RTCTREE_NAMESERVERS" value="$(arg nameserver):$(arg corbaport)" />
   <arg name="omniorb_args" default="-ORBInitRef NameService=corbaloc:iiop:$(arg nameserver):$(arg corbaport)/NameService" />
-  <arg name="openrtm_args" default='-o "corba.nameservers:$(arg nameserver):$(arg corbaport)" -o "naming.formats:%n.rtc" -o "exec_cxt.periodic.type:PeriodicExecutionContext" -o "exec_cxt.periodic.rate:$(arg periodic_rate)" -o "logger.file_name:/tmp/rtc%p.log"' />
+  <arg name="openrtm_args" default='-o "corba.master_manager:$(arg nameserver):$(arg managerport)" -o "corba.nameservers:$(arg nameserver):$(arg corbaport)" -o "naming.formats:%n.rtc" -o "exec_cxt.periodic.type:PeriodicExecutionContext" -o "exec_cxt.periodic.rate:$(arg periodic_rate)" -o "logger.file_name:/tmp/rtc%p.log"' />
   <arg name="subscription_type" default="new" />
   <arg name="push_policy" default="all" />
   <arg name="push_rate" default="50.0" />

--- a/hrpsys_ros_bridge/launch/hrpsys_ros_bridge.launch
+++ b/hrpsys_ros_bridge/launch/hrpsys_ros_bridge.launch
@@ -44,7 +44,7 @@
   <!-- <arg name="managerport" default="$(eval arg('corbaport') + 1)"/> -->
   <arg name="periodic_rate" default="2000" />
   <env name="RTCTREE_NAMESERVERS" value="$(arg nameserver):$(arg corbaport)" />
-  <arg name="omniorb_args" default="-ORBInitRef NameService=corbaloc:iiop:$(arg nameserver):$(arg corbaport)/NameService -RTCManagerPort $(arg managerport)" />
+  <arg name="omniorb_args" default="-ORBInitRef NameService=corbaloc:iiop:$(arg nameserver):$(arg corbaport)/NameService" />
   <arg name="openrtm_args" default='-o "corba.master_manager:$(arg nameserver):$(arg managerport)" -o "corba.nameservers:$(arg nameserver):$(arg corbaport)" -o "naming.formats:%n.rtc" -o "exec_cxt.periodic.type:PeriodicExecutionContext" -o "exec_cxt.periodic.rate:$(arg periodic_rate)" -o "logger.file_name:/tmp/rtc%p.log"' />
   <arg name="subscription_type" default="new" />
   <arg name="push_policy" default="all" />
@@ -86,7 +86,7 @@
         if="$(arg USE_HRPSYS_PROFILE)"/>
 
   <node pkg="hrpsys_ros_bridge" name="sensor_ros_bridge_connect" type="sensor_ros_bridge_connect.py"
-        args="$(arg MODEL_FILE) $(arg SIMULATOR_NAME) HrpsysSeqStateROSBridge0 $(arg nameserver) $(arg subscription_type) $(arg push_policy) $(arg push_rate) $(arg omniorb_args)" output="$(arg OUTPUT)"/>
+        args="$(arg MODEL_FILE) $(arg SIMULATOR_NAME) HrpsysSeqStateROSBridge0 $(arg nameserver) $(arg subscription_type) $(arg push_policy) $(arg push_rate) $(arg openrtm_args)" output="$(arg OUTPUT)"/>
   <!-- BEGIN:openrtm connection -->
   <env name="SIMULATOR_NAME" value="$(arg SIMULATOR_NAME)" />
   <env name="SIMULATOR_NAME_ANGLE"    value="$(arg SIMULATOR_NAME_ANGLE)" />
@@ -183,7 +183,7 @@
     <rtconnect from="CollisionDetectorServiceROSBridge.rtc:CollisionDetectorService" to="co.rtc:CollisionDetectorService" subscription_type="new"/>
     <rtactivate component="CollisionDetectorServiceROSBridge.rtc" />
     <node pkg="hrpsys_ros_bridge" name="collision_state" type="collision_state.py"
-          args="$(arg MODEL_FILE) $(arg omniorb_args)" output="$(arg OUTPUT)"/>
+          args="$(arg MODEL_FILE) $(arg openrtm_args)" output="$(arg OUTPUT)"/>
   </group>
 
   <!-- USE_IMPEDANCECONTROLLER

--- a/hrpsys_ros_bridge/launch/hrpsys_ros_bridge.launch
+++ b/hrpsys_ros_bridge/launch/hrpsys_ros_bridge.launch
@@ -44,6 +44,7 @@
   <!-- <arg name="managerport" default="$(eval arg('corbaport') + 1)"/> -->
   <arg name="periodic_rate" default="2000" />
   <env name="RTCTREE_NAMESERVERS" value="$(arg nameserver):$(arg corbaport)" />
+  <!-- omniorb_args will be obsolete -->
   <arg name="omniorb_args" default="-ORBInitRef NameService=corbaloc:iiop:$(arg nameserver):$(arg corbaport)/NameService" />
   <arg name="openrtm_args" default='-o "corba.master_manager:$(arg nameserver):$(arg managerport)" -o "corba.nameservers:$(arg nameserver):$(arg corbaport)" -o "naming.formats:%n.rtc" -o "exec_cxt.periodic.type:PeriodicExecutionContext" -o "exec_cxt.periodic.rate:$(arg periodic_rate)" -o "logger.file_name:/tmp/rtc%p.log"' />
   <arg name="subscription_type" default="new" />
@@ -86,7 +87,7 @@
         if="$(arg USE_HRPSYS_PROFILE)"/>
 
   <node pkg="hrpsys_ros_bridge" name="sensor_ros_bridge_connect" type="sensor_ros_bridge_connect.py"
-        args="$(arg MODEL_FILE) $(arg SIMULATOR_NAME) HrpsysSeqStateROSBridge0 $(arg nameserver) $(arg subscription_type) $(arg push_policy) $(arg push_rate) $(arg openrtm_args)" output="$(arg OUTPUT)"/>
+        args="$(arg MODEL_FILE) $(arg SIMULATOR_NAME) HrpsysSeqStateROSBridge0 $(arg nameserver) $(arg subscription_type) $(arg push_policy) $(arg push_rate) $(arg openrtm_args) $(arg omniorb_args)" output="$(arg OUTPUT)"/> <!-- omniorb_args is still used for backward compatibility -->
   <!-- BEGIN:openrtm connection -->
   <env name="SIMULATOR_NAME" value="$(arg SIMULATOR_NAME)" />
   <env name="SIMULATOR_NAME_ANGLE"    value="$(arg SIMULATOR_NAME_ANGLE)" />
@@ -183,7 +184,7 @@
     <rtconnect from="CollisionDetectorServiceROSBridge.rtc:CollisionDetectorService" to="co.rtc:CollisionDetectorService" subscription_type="new"/>
     <rtactivate component="CollisionDetectorServiceROSBridge.rtc" />
     <node pkg="hrpsys_ros_bridge" name="collision_state" type="collision_state.py"
-          args="$(arg MODEL_FILE) $(arg openrtm_args)" output="$(arg OUTPUT)"/>
+          args="$(arg MODEL_FILE) $(arg openrtm_args) $(arg omniorb_args)" output="$(arg OUTPUT)"/> <!-- omniorb_args is still used for backward compatibility -->
   </group>
 
   <!-- USE_IMPEDANCECONTROLLER

--- a/hrpsys_ros_bridge/scripts/default_robot.launch.in
+++ b/hrpsys_ros_bridge/scripts/default_robot.launch.in
@@ -34,6 +34,7 @@
     <arg name="SIMULATOR_NAME" value="$(arg SIMULATOR_NAME)" />
     <arg name="RUN_RVIZ" default="$(arg RUN_RVIZ)" />
     <arg name="corbaport" default="$(arg corbaport)" />
+    <arg name="managerport" default="$(arg managerport)" />
     <arg name="USE_UNSTABLE_RTC" default="$(arg USE_UNSTABLE_RTC)"/>
     <!-- BEGIN: development -->
     <arg name="USE_EMERGENCYSTOPPER" default="$(arg USE_EMERGENCYSTOPPER)" />

--- a/hrpsys_ros_bridge/scripts/default_robot.launch.in
+++ b/hrpsys_ros_bridge/scripts/default_robot.launch.in
@@ -8,7 +8,10 @@
   <arg name="PROJECT_FILE" default="$(find @PROJECT_PKG_NAME@)/models/@ROBOT@.xml" unless="$(arg NOSIM)"/>
   <arg name="SIMULATOR_NAME" default="@ROBOT@(Robot)0" />
   <arg name="corbaport" default="15005" />
-  <arg name="managerport" default="15006" />
+  <arg name="managerport" default="2810" />
+  <!-- <arg name="managerport" default="15006" /> -->
+  <!-- available in Kinetic -->
+  <!-- <arg name="managerport" default="$(eval arg('corbaport') + 1)"/> -->
   <arg name="hrpsys_precreate_rtc" default="HGcontroller"/>
   <arg name="USE_UNSTABLE_RTC" default="@USE_UNSTABLE_RTC@"/>
   <!-- following rtc is used for test/hrpsys-samples, mainly full euslisp test -->

--- a/hrpsys_ros_bridge/scripts/default_robot.launch.in
+++ b/hrpsys_ros_bridge/scripts/default_robot.launch.in
@@ -8,6 +8,7 @@
   <arg name="PROJECT_FILE" default="$(find @PROJECT_PKG_NAME@)/models/@ROBOT@.xml" unless="$(arg NOSIM)"/>
   <arg name="SIMULATOR_NAME" default="@ROBOT@(Robot)0" />
   <arg name="corbaport" default="15005" />
+  <arg name="managerport" default="15006" />
   <arg name="hrpsys_precreate_rtc" default="HGcontroller"/>
   <arg name="USE_UNSTABLE_RTC" default="@USE_UNSTABLE_RTC@"/>
   <!-- following rtc is used for test/hrpsys-samples, mainly full euslisp test -->
@@ -21,6 +22,7 @@
     <arg name="SIMULATOR_NAME" value="$(arg SIMULATOR_NAME)" />
     <arg name="REALTIME" default="$(arg REALTIME)" />
     <arg name="corbaport" default="$(arg corbaport)" />
+    <arg name="managerport" default="$(arg managerport)" />
     <arg name="GUI" default="$(arg GUI)" />
     <arg name="hrpsys_precreate_rtc" default="$(arg hrpsys_precreate_rtc)" />
     <arg name="USE_UNSTABLE_RTC" default="$(arg USE_UNSTABLE_RTC)"/>

--- a/hrpsys_ros_bridge/scripts/default_robot_ros_bridge.launch.in
+++ b/hrpsys_ros_bridge/scripts/default_robot_ros_bridge.launch.in
@@ -12,6 +12,10 @@
             file="$(find @PROJECT_PKG_NAME@)/models/@ROBOT@_controller_config.yaml" />
 
   <arg name="corbaport" default="15005" />
+  <arg name="managerport" default="2810" />
+  <!-- <arg name="managerport" default="15006" /> -->
+  <!-- available in Kinetic -->
+  <!-- <arg name="managerport" default="$(eval arg('corbaport') + 1)"/> -->
   <arg name="nameserver" default="localhost" />
   <include file="$(find hrpsys_ros_bridge)/launch/hrpsys_ros_bridge.launch">
     <arg name="SIMULATOR_NAME" value="$(arg SIMULATOR_NAME)" />
@@ -19,6 +23,7 @@
     <arg name="COLLADA_FILE" value="$(find @PROJECT_PKG_NAME@)/models/@ROBOT@.dae" />
     <arg name="CONF_FILE" value="$(find @PROJECT_PKG_NAME@)/models/@ROBOT@.conf" />
     <arg name="corbaport" default="$(arg corbaport)" />
+    <arg name="managerport" default="$(arg managerport)" />
     <arg name="nameserver" default="$(arg nameserver)" />
     <!-- BEGIN: unstable : maintained-->
     <arg name="USE_WALKING" default="true" if="$(arg USE_UNSTABLE_RTC)"/>

--- a/hrpsys_ros_bridge/scripts/default_robot_startup.launch.in
+++ b/hrpsys_ros_bridge/scripts/default_robot_startup.launch.in
@@ -7,6 +7,7 @@
   <arg name="PROJECT_FILE" default="$(find @PROJECT_PKG_NAME@)/models/@ROBOT@_nosim.xml" if="$(arg NOSIM)"/>
   <arg name="PROJECT_FILE" default="$(find @PROJECT_PKG_NAME@)/models/@ROBOT@.xml" unless="$(arg NOSIM)"/>
   <arg name="corbaport" default="15005" />
+  <arg name="managerport" default="15006" />
   <arg name="hrpsys_precreate_rtc" default="HGcontroller"/>
   <arg name="USE_UNSTABLE_RTC" default="@USE_UNSTABLE_RTC@"/>
   <param name="use_sim_time" value="true" />
@@ -18,6 +19,7 @@
     <arg name="KILL_SERVERS" default="$(arg KILL_SERVERS)" />
     <arg name="REALTIME" default="$(arg REALTIME)" />
     <arg name="corbaport" default="$(arg corbaport)" />
+    <arg name="managerport" default="$(arg managerport)" />
     <arg name="GUI" default="$(arg GUI)" />
     <arg name="hrpsys_precreate_rtc" default="$(arg hrpsys_precreate_rtc)" />
 @STARTUP_ARGS@

--- a/hrpsys_ros_bridge/scripts/default_robot_startup.launch.in
+++ b/hrpsys_ros_bridge/scripts/default_robot_startup.launch.in
@@ -7,7 +7,10 @@
   <arg name="PROJECT_FILE" default="$(find @PROJECT_PKG_NAME@)/models/@ROBOT@_nosim.xml" if="$(arg NOSIM)"/>
   <arg name="PROJECT_FILE" default="$(find @PROJECT_PKG_NAME@)/models/@ROBOT@.xml" unless="$(arg NOSIM)"/>
   <arg name="corbaport" default="15005" />
-  <arg name="managerport" default="15006" />
+  <arg name="managerport" default="2810" />
+  <!-- <arg name="managerport" default="15006" /> -->
+  <!-- available in Kinetic -->
+  <!-- <arg name="managerport" default="$(eval arg('corbaport') + 1)"/> -->
   <arg name="hrpsys_precreate_rtc" default="HGcontroller"/>
   <arg name="USE_UNSTABLE_RTC" default="@USE_UNSTABLE_RTC@"/>
   <param name="use_sim_time" value="true" />

--- a/hrpsys_tools/launch/hrpsys.launch
+++ b/hrpsys_tools/launch/hrpsys.launch
@@ -16,10 +16,13 @@
   <!-- BEGIN:openrtm setting -->
   <arg name="nameserver" default="localhost" />
   <arg name="corbaport" default="15005" />
+  <arg name="managerport" default="15006" />
+  <!-- available in Kinetic -->
+  <!-- <arg name="managerport" default="$(eval arg('corbaport') + 1)"/> -->
   <arg name="KILL_SERVERS" default="false" />
   <env name="RTCTREE_NAMESERVERS" value="$(arg nameserver):$(arg corbaport)" />
   <arg name="omniorb_args" default="-ORBInitRef NameService=corbaloc:iiop:$(arg nameserver):$(arg corbaport)/NameService" />
-  <arg name="openrtm_args" default='-o "corba.nameservers:$(arg nameserver):$(arg corbaport)" -o "naming.formats:%n.rtc" -o "logger.file_name:/tmp/rtc%p.log" ' />
+  <arg name="openrtm_args" default='-o "corba.master_manager:$(arg nameserver):$(arg managerport)" -o "corba.nameservers:$(arg nameserver):$(arg corbaport)" -o "naming.formats:%n.rtc" -o "logger.file_name:/tmp/rtc%p.log"' />
   <!-- END:openrtm setting -->
 
   <!-- BEGIN:setting for hrpsys-simulator or rtcd -->

--- a/hrpsys_tools/launch/hrpsys.launch
+++ b/hrpsys_tools/launch/hrpsys.launch
@@ -16,7 +16,8 @@
   <!-- BEGIN:openrtm setting -->
   <arg name="nameserver" default="localhost" />
   <arg name="corbaport" default="15005" />
-  <arg name="managerport" default="15006" />
+  <arg name="managerport" default="2810" />
+  <!-- <arg name="managerport" default="15006" /> -->
   <!-- available in Kinetic -->
   <!-- <arg name="managerport" default="$(eval arg('corbaport') + 1)"/> -->
   <arg name="KILL_SERVERS" default="false" />

--- a/hrpsys_tools/launch/hrpsys.launch
+++ b/hrpsys_tools/launch/hrpsys.launch
@@ -139,8 +139,8 @@
 
   <group if="$(arg LAUNCH_HRPSYSPY)">
     <node name="hrpsys_py" pkg="$(arg HRPSYS_PY_PKG)" type="$(arg HRPSYS_PY_NAME)" output="screen"
-          args='$(arg HRPSYS_PY_ARGS) $(arg SIMULATOR_NAME) $(arg MODEL_FILE) $(arg openrtm_args)'
-          launch-prefix="$(arg PY_LAUNCH_PREFIX)" />
+          args='$(arg HRPSYS_PY_ARGS) $(arg SIMULATOR_NAME) $(arg MODEL_FILE) $(arg openrtm_args) $(arg omniorb_args)'
+          launch-prefix="$(arg PY_LAUNCH_PREFIX)" /> <!-- omniorb_args is still used for backward compatibility -->
   </group>
 
   <!-- <node name="abstransform2posrpy" pkg="hrpsys" type="AbsTransformToPosRpy" output="$(arg OUTPUT)" -->

--- a/hrpsys_tools/launch/hrpsys.launch
+++ b/hrpsys_tools/launch/hrpsys.launch
@@ -22,7 +22,7 @@
   <!-- <arg name="managerport" default="$(eval arg('corbaport') + 1)"/> -->
   <arg name="KILL_SERVERS" default="false" />
   <env name="RTCTREE_NAMESERVERS" value="$(arg nameserver):$(arg corbaport)" />
-  <arg name="omniorb_args" default="-ORBInitRef NameService=corbaloc:iiop:$(arg nameserver):$(arg corbaport)/NameService" />
+  <arg name="omniorb_args" default="-ORBInitRef NameService=corbaloc:iiop:$(arg nameserver):$(arg corbaport)/NameService -RTCManagerPort $(arg managerport)" />
   <arg name="openrtm_args" default='-o "corba.master_manager:$(arg nameserver):$(arg managerport)" -o "corba.nameservers:$(arg nameserver):$(arg corbaport)" -o "naming.formats:%n.rtc" -o "logger.file_name:/tmp/rtc%p.log"' />
   <!-- END:openrtm setting -->
 

--- a/hrpsys_tools/launch/hrpsys.launch
+++ b/hrpsys_tools/launch/hrpsys.launch
@@ -22,7 +22,7 @@
   <!-- <arg name="managerport" default="$(eval arg('corbaport') + 1)"/> -->
   <arg name="KILL_SERVERS" default="false" />
   <env name="RTCTREE_NAMESERVERS" value="$(arg nameserver):$(arg corbaport)" />
-  <arg name="omniorb_args" default="-ORBInitRef NameService=corbaloc:iiop:$(arg nameserver):$(arg corbaport)/NameService -RTCManagerPort $(arg managerport)" />
+  <arg name="omniorb_args" default="-ORBInitRef NameService=corbaloc:iiop:$(arg nameserver):$(arg corbaport)/NameService" />
   <arg name="openrtm_args" default='-o "corba.master_manager:$(arg nameserver):$(arg managerport)" -o "corba.nameservers:$(arg nameserver):$(arg corbaport)" -o "naming.formats:%n.rtc" -o "logger.file_name:/tmp/rtc%p.log"' />
   <!-- END:openrtm setting -->
 
@@ -139,7 +139,7 @@
 
   <group if="$(arg LAUNCH_HRPSYSPY)">
     <node name="hrpsys_py" pkg="$(arg HRPSYS_PY_PKG)" type="$(arg HRPSYS_PY_NAME)" output="screen"
-          args='$(arg HRPSYS_PY_ARGS) $(arg SIMULATOR_NAME) $(arg MODEL_FILE) $(arg omniorb_args)'
+          args='$(arg HRPSYS_PY_ARGS) $(arg SIMULATOR_NAME) $(arg MODEL_FILE) $(arg openrtm_args)'
           launch-prefix="$(arg PY_LAUNCH_PREFIX)" />
   </group>
 

--- a/openrtm_tools/scripts/rtmlaunch
+++ b/openrtm_tools/scripts/rtmlaunch
@@ -23,17 +23,20 @@ Here 3 things are happening:
 '''
 
 from openrtm_tools import rtmstart, rtmlaunch
+from rosgraph import names
 import roslaunch, sys
 
 cosnames = "omniNames"
 
 port_number = 15005 # default
 
-for arg in sys.argv:
-    if arg.startswith("corbaport:="):
-        port_number = int(arg.lstrip("corbaport:="))
-        print "\033[34m[rtmlaunch] command line corbaport:= option used, set nameserver port", port_number, "\033[0m"
-        break
+arg_remap = names.load_mappings(sys.argv)
+
+if arg_remap['corbaport']:
+    port_number = int(arg_remap['corbaport'])
+    print "\033[34m[rtmlaunch] user defined corbaport:=", port_number, "will be used\033[0m"
+else:
+    print "\033[34m[rtmlaunch] default corbaport:=", port_number, "will be used\033[0m"
 
 p = rtmstart.start_cosname(cosnames, port_number)
 

--- a/openrtm_tools/scripts/rtmlaunch
+++ b/openrtm_tools/scripts/rtmlaunch
@@ -32,8 +32,6 @@ port_number = 15005 # default
 
 arg_remap = names.load_mappings(sys.argv)
 
-print arg_remap
-
 if 'corbaport' in arg_remap:
     port_number = int(arg_remap['corbaport'])
     print "\033[34m[rtmlaunch] user defined corbaport:=", port_number, "will be used\033[0m"

--- a/openrtm_tools/scripts/rtmlaunch
+++ b/openrtm_tools/scripts/rtmlaunch
@@ -22,11 +22,18 @@ Here 3 things are happening:
   3. Specify rtconnect tag with connecting components info.
 '''
 
-cosnames = "omniNames"
-port_number = 15005
-
 from openrtm_tools import rtmstart, rtmlaunch
-import roslaunch
+import roslaunch, sys
+
+cosnames = "omniNames"
+
+port_number = 15005 # default
+
+for arg in sys.argv:
+    if arg.startswith("corbaport:="):
+        port_number = int(arg.lstrip("corbaport:="))
+        print "\033[34m[rtmlaunch] command line corbaport:= option used, set nameserver port", port_number, "\033[0m"
+        break
 
 p = rtmstart.start_cosname(cosnames, port_number)
 

--- a/openrtm_tools/scripts/rtmlaunch
+++ b/openrtm_tools/scripts/rtmlaunch
@@ -32,7 +32,9 @@ port_number = 15005 # default
 
 arg_remap = names.load_mappings(sys.argv)
 
-if arg_remap['corbaport']:
+print arg_remap
+
+if 'corbaport' in arg_remap:
     port_number = int(arg_remap['corbaport'])
     print "\033[34m[rtmlaunch] user defined corbaport:=", port_number, "will be used\033[0m"
 else:


### PR DESCRIPTION
同じＰＣ内で複数のCORBA nameserver + RTC manager + RTC群　を干渉なく立ち上げるためのissueも兼ねたPRです．

1. rtmlaunchがコマンドライン引数から受け取るポート番号と，
2. roslaunchが.launch内のcorbaportタグ経由で各RTCに伝えるポート番号と，
3. 環境変数RTCTREE_NAMESERVERS=localhost:15005を読み込んで解釈したポート番号，

があり，今回は1.と2.について整備しました
(3.はいつ効いてくるのか不明，hrpsys.launchで毎回上書かれている気もする→`<env name="RTCTREE_NAMESERVERS" value="$(arg nameserver):$(arg corbaport)" />`)

```
rtmlaunch hrpsys_ros_bridge_tutorials samplerobot_startup.launch corbaport:=25005 managerport:=25006
rtmlaunch hrpsys_ros_bridge_tutorials samplerobot_startup.launch corbaport:=35005 managerport:=35006
```

とするとrtmlaunch自身が起動するCORBAnameserver+RTCManagerのポート番号と，
hrpsys.launch経由でhrpsysの諸々が参照しに行くCORBAnameserver+RTCManagerのポート番号が一致した状態でかつ任意に変更できるようになります(nameserverとmanagerのポート番号が隣り合う制限は依然ある)

rosbridgeまで起動できるようにするためにはroscoreのmultimasterあたりが一仕事になりそうなので，まずはここで一区切りです．

https://github.com/fkanehiro/hrpsys-base/pull/1253
が必要．