### PR TITLE
[collision_state.py]fix argument of rospy.loginfo

### DIFF
--- a/hrpsys_ros_bridge/scripts/collision_state.py
+++ b/hrpsys_ros_bridge/scripts/collision_state.py
@@ -38,7 +38,7 @@ def rtc_init () :
     while ms == None :
         time.sleep(1);
         ms = rtm.findRTCmanager(rtm.nshost)
-        rospy.loginfo("[collision_state.py] wait for RTCmanager : ",ms)
+        rospy.loginfo("[collision_state.py] wait for RTCmanager : %s",ms)
 
     co = None
     count = 0


### PR DESCRIPTION
collision_state.pyで下記のようなエラーが出ました．
```
Traceback (most recent call last):
  File "/home/hiraoka/hiraoka_ws/default_ws/src/rtm-ros-robotics/rtmros_common/hrpsys_ros_bridge/scripts/collision_state.py", line 191, in <module>
    rtc_init()
  File "/home/hiraoka/hiraoka_ws/default_ws/src/rtm-ros-robotics/rtmros_common/hrpsys_ros_bridge/scripts/collision_state.py", line 41, in rtc_init
    rospy.loginfo("[collision_state.py] wait for RTCmanager : ",ms)
  File "/usr/lib/python2.7/logging/__init__.py", line 1167, in info
    self._log(INFO, msg, args, **kwargs)
  File "/usr/lib/python2.7/logging/__init__.py", line 1286, in _log
    self.handle(record)
  File "/usr/lib/python2.7/logging/__init__.py", line 1296, in handle
.    self.callHandlers(record)
  File "/usr/lib/python2.7/logging/__init__.py", line 1336, in callHandlers
    hdlr.handle(record)
  File "/usr/lib/python2.7/logging/__init__.py", line 759, in handle
    self.emit(record)
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/rosgraph/roslogging.py", line 182, in emit
    record_message = _defaultFormatter.format(record)
  File "/usr/lib/python2.7/logging/__init__.py", line 465, in format
    record.message = record.getMessage()
  File "/usr/lib/python2.7/logging/__init__.py", line 329, in getMessage
    msg = msg % self.args
[collision_state-21] process has died [pid 12477, exit code 1, cmd /home/hiraoka/hiraoka_ws/default_ws/src/rtm-ros-robotics/rtmros_common/hrpsys_ros_bridge/scripts/collision_state.py /home/hiraoka/hiraoka_ws/default_ws/src/rtm-ros-robotics/rtmros_tutorials/hrpsys_ros_bridge_tutorials/models/HRP2JSKNTS.dae -ORBInitRef NameService=corbaloc:iiop:localhost:15005/NameService __name:=collision_state __log:=/home/hiraoka/.ros/log/cf2d7c2a-ab3f-11e8-bc27-5c514f34f247/collision_state-21.log].
log file: /home/hiraoka/.ros/log/cf2d7c2a-ab3f-11e8-bc27-5c514f34f247/collision_state-21*.log
```

https://github.com/start-jsk/rtmros_common/blob/0beacf48e22cb19d4b591d10fd6f66ffb0301b35/hrpsys_ros_bridge/scripts/collision_state.py#L41
のrospy.loginfoの引数を修正すると直りました．