### PR TITLE
Remove all ros::object slots in def-set-get-param-method

### DIFF
--- a/hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l
+++ b/hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l
@@ -329,9 +329,13 @@
         (debug nil))
   (when (boundp param-class)
     (let* ((param-slots-list ;; get slots list for param-class
-            (remove-if #'(lambda (x) (or (string= "plist" x) (string= "connection-header" x)))
-                       (mapcar #'(lambda (x) (string-left-trim "::_" (string-left-trim "ros" (format nil "~A" x))))
-                               (concatenate cons (send (eval param-class) :slots)))))
+            ;; coerce to cons to avoid :count glitches on vectors
+            ;; https://github.com/euslisp/EusLisp/issues/295
+            (let ((slt (coerce (send (eval param-class) :slots) cons)))
+              (map nil #'(lambda (obj) (setq slt (remove obj slt :count 1)))
+                   (send ros::object :slots))
+              (mapcar #'(lambda (x) (string-left-trim "_" (symbol-name x)))
+                      slt)))
            (param-name
             ;; Extract param class, e.g., extract zz from hrpsys_ros_bridge::xx_yy_zz
             (car (last (read-from-string (substitute (elt " " 0) (elt ":" 0) (substitute (elt " " 0) (elt "_" 0) (format nil "(~A)" param-class)))))))


### PR DESCRIPTION
Removing all `ros::object` slots instead of `plist` and `_connection-header` in `def-set-get-param-method`, so that even if definition of `ros::object` changes in the future this code remains functional.
https://github.com/jsk-ros-pkg/jsk_roseus/pull/606

Also changing to use `symbol-name` instead of `format`. Strings get to uppercase, but since they are `read-string`ed afterwards should make no difference.

**>>Need testing<<**

Btw some random notes:
- I'm pretty sure that `string-left-trim` is not the right function here, specially if `rtc_name` may contain underscores.
https://github.com/start-jsk/rtmros_common/blob/0ac88687c3bb4dc9bf125ec869a24aea134b6580/hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l#L236-L258
https://github.com/euslisp/EusLisp/issues/249
https://github.com/euslisp/EusLisp/issues/336

- `(elt ":" 0)` => `#\:`