### PR TITLE
[HrpsysSeqStateROSBridge] output joint_state/velocity

### DIFF
--- a/hrpsys_ros_bridge/launch/hrpsys_ros_bridge.launch
+++ b/hrpsys_ros_bridge/launch/hrpsys_ros_bridge.launch
@@ -30,7 +30,7 @@
   <arg name="USE_REFERENCEFORCEUPDATER" default="false" />
   <arg name="USE_OBJECTCONTACTTURNAROUNDDETECTOR" default="false" />
   <arg name="USE_HRPSYS_PROFILE" default="true" />
-  <arg name="USE_VELOCITY_OUTPUT" default="false" />
+  <arg name="USE_VELOCITY_OUTPUT" default="false" doc="true: output actual velocity / false: output differential value of actual postition as /joint_states/velocity"/>
   <arg name="PUBLISH_SENSOR_TF" default="true" />
   <!--
       roslaunch hrpsys_ros_bridge sample.launch nameserver:=192.168.1.1

--- a/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.cpp
+++ b/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.cpp
@@ -463,8 +463,16 @@ RTC::ReturnCode_t HrpsysSeqStateROSBridge::onExecute(RTC::UniqueId ec_id)
         joint_state.velocity.push_back(m_rsvel.data[i]);
       }
     } else {
-      joint_state.velocity.resize(joint_state.name.size());
+      double time_from_prev = (joint_state.header.stamp - prev_joint_state.header.stamp).toSec();
+      if(time_from_prev > 0 && prev_joint_state.position.size() == joint_state.position.size()) {
+        for (unsigned int i = 0; i < joint_state.position.size(); i++) {
+          joint_state.velocity.push_back((joint_state.position[i] - prev_joint_state.position[i]) / time_from_prev);
+        }
+      } else {
+        joint_state.velocity.resize(joint_state.name.size());
+      }
     }
+    prev_joint_state = joint_state;
     // set effort if m_rstorque is available
     if (m_rstorque.data.length() == body->joints().size()) {
       for ( unsigned int i = 0; i < body->joints().size() ; i++ ){

--- a/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.h
+++ b/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.h
@@ -75,6 +75,7 @@ class HrpsysSeqStateROSBridge  : public HrpsysSeqStateROSBridgeImpl
 
   coil::Mutex m_mutex;
   coil::TimeMeasure tm;
+  sensor_msgs::JointState prev_joint_state;
 
   std::string nameserver;
   std::string rootlink_name;

--- a/hrpsys_ros_bridge/test/test-pa10.py
+++ b/hrpsys_ros_bridge/test/test-pa10.py
@@ -18,6 +18,7 @@ from hrpsys_ros_bridge.srv import OpenHRP_SequencePlayerService_loadPattern, Ope
 
 import actionlib
 
+from sensor_msgs.msg import JointState
 from trajectory_msgs.msg import JointTrajectoryPoint, JointTrajectory
 
 class TestPA10Robot(unittest.TestCase):
@@ -25,7 +26,7 @@ class TestPA10Robot(unittest.TestCase):
     lfsensor = None
     rfsensor = None
 
-    def send_joint_angles(self,angles):
+    def send_joint_angles(self,angles,wait=True):
         pub = rospy.Publisher("/fullbody_controller/command", JointTrajectory)
         point = JointTrajectoryPoint()
         point.positions = [ x * math.pi / 180.0 for x in angles ]
@@ -35,7 +36,8 @@ class TestPA10Robot(unittest.TestCase):
         msg.joint_names = ["J1","J2","J3","J4","J5","J6","J7"]
         msg.points = [point]
         pub.publish(msg)
-        rospy.sleep(rospy.Duration(6.0))
+        if wait:
+            rospy.sleep(rospy.Duration(6.0))
 
     def setUp(self):
         rospy.init_node('TestPA10Robot')
@@ -111,6 +113,22 @@ class TestPA10Robot(unittest.TestCase):
         rospy.logwarn("tf_echo /BASE_LINK /J7_LINK %r %r"%(trans2,rot2))
         rospy.logwarn("difference between two /J7_LINK %r %r"%(array(trans1)-array(trans2),linalg.norm(array(trans1)-array(trans2))))
         self.assertNotAlmostEqual(linalg.norm(array(trans1)-array(trans2)), 0, delta=0.1)
+
+    def test_joint_states_velocity(self):
+        cmd_angles = [20,20,20,20,20,20,20]
+        self.send_joint_angles(cmd_angles, wait=False)
+        rospy.sleep(rospy.Duration(2.5))
+        jt_st = rospy.wait_for_message('/joint_states', JointState)
+        rospy.sleep(rospy.Duration(2.5))
+        # When acceleration and deceleration are constant and take the same time,
+        # (max velocity) = 2 * (target joint angle) / (whole execution time)
+        pred_vel = [2 * (x * math.pi / 180.0) / 5.0 for x in cmd_angles]
+        # get velocity of joints except hand
+        real_vel = [v for i, v in enumerate(jt_st.velocity) if 'HAND' not in jt_st.name[i]]
+        rospy.logwarn("real velocity: %r"%(array(real_vel)))
+        rospy.logwarn("difference from predicted velocity: %r"%(linalg.norm(array(real_vel)-array(pred_vel))))
+        self.assertAlmostEqual(linalg.norm(array(real_vel)-array(pred_vel)), 0, delta=0.1)
+
 
 # unittest.main()
 if __name__ == '__main__':


### PR DESCRIPTION
```/joint_states```トピックの```velocity```は、
https://github.com/start-jsk/rtmros_common/blob/b24e954840f891698d9a110d994bb18ac5658be6/hrpsys_ros_bridge/launch/hrpsys_ros_bridge.launch#L33
が```false```となっていると常に0が入るようになっています。

これは、ハードウェア的に関節速度を計測することができず、
https://github.com/fkanehiro/hrpsys-base/blob/5cbb5490f55c7017f7ff789c3d9de531ba92e1b6/lib/io/iob.h#L389
の関数で関節速度が取得できないロボットに対応するためと理解しています。

ところが、```/joint_states/velocity```が常に0だと、速度の値を見てロボットが静止したかどうかを判定することを利用するライブラリがうまく働かないという不便があります。
_そのようなプログラムの例：_ 
http://wiki.ros.org/robot_calibration
https://github.com/mikeferguson/robot_calibration/blob/04aa2d1b98b630e0acc547ca8dfefb5ea65958fc/robot_calibration/src/chain_manager.cpp#L255

```/joint_states/velocity```を常に0にする代わりに、```/joint_states/position```の変化から計算した値を入れるようにしました。