### PR TITLE
Fix travis

### DIFF
--- a/.travis.rosinstall.hydro
+++ b/.travis.rosinstall.hydro
@@ -1,8 +1,0 @@
-# As .travis.yml forcely upgrade PCRE to avoid failure in building hrpsys with hydro, hrpsys_state_publisher dies:
-# https://github.com/start-jsk/rtmros_common/pull/1077#issuecomment-552102475
-# To avoid this, the following PRs are required:
-# https://github.com/ros/robot_model/pull/105, https://github.com/ros/robot_model/pull/106, https://github.com/ros/robot_model/pull/108
-- git:
-    uri: https://github.com/pazeshun/robot_model.git
-    local-name: robot_model
-    version: for-hydro-with-new-pcre

--- a/.travis.rosinstall.hydro
+++ b/.travis.rosinstall.hydro
@@ -3,6 +3,6 @@
 # To avoid this, the following PRs are required:
 # https://github.com/ros/robot_model/pull/105, https://github.com/ros/robot_model/pull/106, https://github.com/ros/robot_model/pull/108
 - git:
-    uri: https://github.com/ros/robot_model.git
+    uri: https://github.com/pazeshun/robot_model.git
     local-name: robot_model
-    version: 6534424
+    version: for-hydro-with-new-pcre

--- a/.travis.rosinstall.hydro
+++ b/.travis.rosinstall.hydro
@@ -1,0 +1,8 @@
+# As .travis.yml forcely upgrade PCRE to avoid failure in building hrpsys with hydro, hrpsys_state_publisher dies:
+# https://github.com/start-jsk/rtmros_common/pull/1077#issuecomment-552102475
+# To avoid this, the following PRs are required:
+# https://github.com/ros/robot_model/pull/105, https://github.com/ros/robot_model/pull/106, https://github.com/ros/robot_model/pull/108
+- git:
+    uri: https://github.com/ros/robot_model.git
+    local-name: robot_model
+    version: 6534424

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,12 @@ before_script:
   # .deb can be got from https://pkgs.org (e.g., https://pkgs.org/download/libpcre3)
   # libpcre3-dev requires the same version of libpcrecpp0
   - if [ "${ROS_DISTRO}" == "hydro" ] && [ "${USE_DEB}" != "true" ] ; then add_scr="wget archive.ubuntu.com/ubuntu/pool/main/p/pcre3/libpcre3_8.31-2ubuntu2_amd64.deb; wget archive.ubuntu.com/ubuntu/pool/main/p/pcre3/libpcrecpp0_8.31-2ubuntu2_amd64.deb; wget archive.ubuntu.com/ubuntu/pool/main/p/pcre3/libpcre3-dev_8.31-2ubuntu2_amd64.deb; sudo dpkg -i libpcre3_8.31-2ubuntu2_amd64.deb; sudo dpkg -i libpcrecpp0_8.31-2ubuntu2_amd64.deb; sudo dpkg -i libpcre3-dev_8.31-2ubuntu2_amd64.deb; sudo apt-mark hold libpcre3 libpcrecpp0 libpcre3-dev"; fi; if [ "${BEFORE_SCRIPT}" == "" ] ; then export BEFORE_SCRIPT=${add_scr}; else export BEFORE_SCRIPT="${BEFORE_SCRIPT}; ${add_scr}"; fi
+  # Forcely upgrading PCRE makes hrpsys_state_publisher dies:
+  # https://github.com/start-jsk/rtmros_common/pull/1077#issuecomment-552102475
+  # To avoid this, the following PRs are required:
+  # https://github.com/ros/robot_model/pull/105, https://github.com/ros/robot_model/pull/106, https://github.com/ros/robot_model/pull/108
+  # Also, see https://github.com/start-jsk/rtmros_common/pull/1077#issuecomment-552121026
+  - if [ "${ROS_DISTRO}" == "hydro" ] && [ "${USE_DEB}" != "true" ] ; then export BEFORE_SCRIPT="${BEFORE_SCRIPT}; wstool set -y robot_model --git https://github.com/pazeshun/robot_model.git -v for-hydro-with-new-pcre; wstool update"; fi
 script:
   - if [ "${IS_EUSLISP_TRAVIS_TEST}" != "true" ] ; then export ROS_PARALLEL_JOBS="-j2 -l2" ; fi
   - if [ "${ROS_DISTRO}" == "hydro" ] ; then sudo apt-get install -y --force-yes gdebi && wget https://bintray.com/artifact/download/furushchev/ros-shadow-fixed/python-catkin-tools_0.3.1-1_all.deb && wget https://bintray.com/artifact/download/furushchev/ros-shadow-fixed/python-catkin-pkg_0.2.10-1_all.deb && sudo gdebi -n -q python-catkin-pkg_0.2.10-1_all.deb && sudo gdebi -n -q python-catkin-tools_0.3.1-1_all.deb && sudo apt-mark hold python-catkin-tools; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ before_script:
   - export REPOSITORY_NAME=`basename $PWD`
   - if [ "${INSTALL_SRC}" != "" ] ;then export sudo apt-get install python-yaml; export BEFORE_SCRIPT="$(for src in $INSTALL_SRC; do name=`basename $src`; echo "python -c \"import yaml;print yaml.dump([{\\\"git\\\":{\\\"uri\\\":\\\"$src\\\",\\\"local-name\\\":\\\"$name\\\"}}], default_flow_style=False)\" >> .rosinstall;"; done)ls -al; cat .rosinstall; wstool update"; export USE_DEB=false; fi; # set USE_DEB false to enable .travis.rosinstall
   # Forcely upgrade PCRE to avoid failure in building hrpsys with hydro.
-  # This has a side effect, and we need extra settings in setup_upstream.sh and .travis.rosinstall.hydro
+  # This has a side effect, and we need extra settings.
   # Issue detail: https://github.com/start-jsk/rtmros_common/issues/1076
   # .deb can be got from https://pkgs.org (e.g., https://pkgs.org/download/libpcre3)
   # libpcre3-dev requires the same version of libpcrecpp0

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ script:
   # https://github.com/start-jsk/rtmros_common/issues/1076
   # .deb can be got from https://pkgs.org (e.g., https://pkgs.org/download/libpcre3)
   # libpcre3-dev requires the same version of libpcrecpp0
-  - if [ "${ROS_DISTRO}" == "hydro" ] && [ "${USE_DEB}" != "true" ] ; then export BEFORE_SCRIPT="wget archive.ubuntu.com/ubuntu/pool/main/p/pcre3/libpcre3_8.31-2ubuntu2_amd64.deb; wget archive.ubuntu.com/ubuntu/pool/main/p/pcre3/libpcrecpp0_8.31-2ubuntu2_amd64.deb; wget archive.ubuntu.com/ubuntu/pool/main/p/pcre3/libpcre3-dev_8.31-2ubuntu2_amd64.deb; sudo dpkg -i libpcre3_8.31-2ubuntu2_amd64.deb; sudo dpkg -i libpcrecpp0_8.31-2ubuntu2_amd64.deb; sudo dpkg -i libpcre3-dev_8.31-2ubuntu2_amd64.deb; sudo apt-mark hold libpcre3 libpcrecpp0 libpcre3-dev"; fi
+  - if [ "${ROS_DISTRO}" == "hydro" ] && [ "${USE_DEB}" != "true" ] ; then add_scr="wget archive.ubuntu.com/ubuntu/pool/main/p/pcre3/libpcre3_8.31-2ubuntu2_amd64.deb; wget archive.ubuntu.com/ubuntu/pool/main/p/pcre3/libpcrecpp0_8.31-2ubuntu2_amd64.deb; wget archive.ubuntu.com/ubuntu/pool/main/p/pcre3/libpcre3-dev_8.31-2ubuntu2_amd64.deb; sudo dpkg -i libpcre3_8.31-2ubuntu2_amd64.deb; sudo dpkg -i libpcrecpp0_8.31-2ubuntu2_amd64.deb; sudo dpkg -i libpcre3-dev_8.31-2ubuntu2_amd64.deb; sudo apt-mark hold libpcre3 libpcrecpp0 libpcre3-dev"; fi; if [ "${BEFORE_SCRIPT}" == "" ] ; then export BEFORE_SCRIPT=${add_scr}; else export BEFORE_SCRIPT="${BEFORE_SCRIPT}; ${add_scr}"; fi
   - if [ "${TEST_TYPE}" == "" ] ; then source .travis/travis.sh; else source ./.travis_test.sh ; fi
   - ccache -s
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ script:
   # https://github.com/start-jsk/rtmros_common/issues/1076
   # .deb can be got from https://pkgs.org (e.g., https://pkgs.org/download/libpcre3)
   # libpcre3-dev requires the same version of libpcrecpp0
-  - if [ "${ROS_DISTRO}" == "hydro" ] && [ "${USE_DEB}" != "true" ] ; then wget archive.ubuntu.com/ubuntu/pool/main/p/pcre3/libpcre3_8.31-2ubuntu2_amd64.deb && wget archive.ubuntu.com/ubuntu/pool/main/p/pcre3/libpcrecpp0_8.31-2ubuntu2_amd64.deb && wget archive.ubuntu.com/ubuntu/pool/main/p/pcre3/libpcre3-dev_8.31-2ubuntu2_amd64.deb && sudo dpkg -i libpcre3_8.31-2ubuntu2_amd64.deb && sudo dpkg -i libpcrecpp0_8.31-2ubuntu2_amd64.deb && sudo dpkg -i libpcre3-dev_8.31-2ubuntu2_amd64.deb && sudo apt-mark hold libpcre3 libpcrecpp0 libpcre3-dev; fi
+  - if [ "${ROS_DISTRO}" == "hydro" ] && [ "${USE_DEB}" != "true" ] ; then export BEFORE_SCRIPT="wget archive.ubuntu.com/ubuntu/pool/main/p/pcre3/libpcre3_8.31-2ubuntu2_amd64.deb && wget archive.ubuntu.com/ubuntu/pool/main/p/pcre3/libpcrecpp0_8.31-2ubuntu2_amd64.deb && wget archive.ubuntu.com/ubuntu/pool/main/p/pcre3/libpcre3-dev_8.31-2ubuntu2_amd64.deb && sudo dpkg -i libpcre3_8.31-2ubuntu2_amd64.deb && sudo dpkg -i libpcrecpp0_8.31-2ubuntu2_amd64.deb && sudo dpkg -i libpcre3-dev_8.31-2ubuntu2_amd64.deb && sudo apt-mark hold libpcre3 libpcrecpp0 libpcre3-dev"; fi
   - if [ "${TEST_TYPE}" == "" ] ; then source .travis/travis.sh; else source ./.travis_test.sh ; fi
   - ccache -s
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,8 @@ before_script:
   - export REPOSITORY_NAME=`basename $PWD`
   - if [ "${INSTALL_SRC}" != "" ] ;then export sudo apt-get install python-yaml; export BEFORE_SCRIPT="$(for src in $INSTALL_SRC; do name=`basename $src`; echo "python -c \"import yaml;print yaml.dump([{\\\"git\\\":{\\\"uri\\\":\\\"$src\\\",\\\"local-name\\\":\\\"$name\\\"}}], default_flow_style=False)\" >> .rosinstall;"; done)ls -al; cat .rosinstall; wstool update"; export USE_DEB=false; fi; # set USE_DEB false to enable .travis.rosinstall
   # Forcely upgrade PCRE to avoid failure in building hrpsys with hydro.
-  # https://github.com/start-jsk/rtmros_common/issues/1076
+  # This has a side effect, and we need extra settings in setup_upstream.sh and .travis.rosinstall.hydro
+  # Issue detail: https://github.com/start-jsk/rtmros_common/issues/1076
   # .deb can be got from https://pkgs.org (e.g., https://pkgs.org/download/libpcre3)
   # libpcre3-dev requires the same version of libpcrecpp0
   - if [ "${ROS_DISTRO}" == "hydro" ] && [ "${USE_DEB}" != "true" ] ; then add_scr="wget archive.ubuntu.com/ubuntu/pool/main/p/pcre3/libpcre3_8.31-2ubuntu2_amd64.deb; wget archive.ubuntu.com/ubuntu/pool/main/p/pcre3/libpcrecpp0_8.31-2ubuntu2_amd64.deb; wget archive.ubuntu.com/ubuntu/pool/main/p/pcre3/libpcre3-dev_8.31-2ubuntu2_amd64.deb; sudo dpkg -i libpcre3_8.31-2ubuntu2_amd64.deb; sudo dpkg -i libpcrecpp0_8.31-2ubuntu2_amd64.deb; sudo dpkg -i libpcre3-dev_8.31-2ubuntu2_amd64.deb; sudo apt-mark hold libpcre3 libpcrecpp0 libpcre3-dev"; fi; if [ "${BEFORE_SCRIPT}" == "" ] ; then export BEFORE_SCRIPT=${add_scr}; else export BEFORE_SCRIPT="${BEFORE_SCRIPT}; ${add_scr}"; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ before_script:
   # To avoid this, the following PRs are required:
   # https://github.com/ros/robot_model/pull/105, https://github.com/ros/robot_model/pull/106, https://github.com/ros/robot_model/pull/108
   # Also, see https://github.com/start-jsk/rtmros_common/pull/1077#issuecomment-552121026
-  - if [ "${ROS_DISTRO}" == "hydro" ] && [ "${USE_DEB}" != "true" ] ; then export BEFORE_SCRIPT="${BEFORE_SCRIPT}; wstool set -y robot_model --git https://github.com/pazeshun/robot_model.git -v for-hydro-with-new-pcre; wstool update"; fi
+  - if [ "${ROS_DISTRO}" == "hydro" ] && [ "${USE_DEB}" != "true" ] ; then export BEFORE_SCRIPT="${BEFORE_SCRIPT}; wstool set -y robot_model --git https://github.com/pazeshun/robot_model.git -v for-hydro-with-new-pcre; wstool update"; export ROSDEP_ADDITIONAL_OPTIONS="-n -q -r --ignore-src --skip-keys=liburdfdom-dev --skip-keys=liburdfdom-headers-dev"; fi
 script:
   - if [ "${IS_EUSLISP_TRAVIS_TEST}" != "true" ] ; then export ROS_PARALLEL_JOBS="-j2 -l2" ; fi
   - if [ "${ROS_DISTRO}" == "hydro" ] ; then sudo apt-get install -y --force-yes gdebi && wget https://bintray.com/artifact/download/furushchev/ros-shadow-fixed/python-catkin-tools_0.3.1-1_all.deb && wget https://bintray.com/artifact/download/furushchev/ros-shadow-fixed/python-catkin-pkg_0.2.10-1_all.deb && sudo gdebi -n -q python-catkin-pkg_0.2.10-1_all.deb && sudo gdebi -n -q python-catkin-tools_0.3.1-1_all.deb && sudo apt-mark hold python-catkin-tools; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,14 +51,14 @@ before_script:
   - if [ "${TRAVIS_SECURE_ENV_VARS}" == "true" ]; then openssl aes-256-cbc -K $encrypted_b79fc5843df3_key -iv $encrypted_b79fc5843df3_iv -in .secrets.tar.enc -out .secrets.tar -d; tar -C ~/ -xvf .secrets.tar; export INSTALL_SRC="$INSTALL_SRC $INSTALL_SRC_SECURE"; export TEST_PKGS="$TEST_PKGS $TEST_PKGS_SECURE"; fi
   - export REPOSITORY_NAME=`basename $PWD`
   - if [ "${INSTALL_SRC}" != "" ] ;then export sudo apt-get install python-yaml; export BEFORE_SCRIPT="$(for src in $INSTALL_SRC; do name=`basename $src`; echo "python -c \"import yaml;print yaml.dump([{\\\"git\\\":{\\\"uri\\\":\\\"$src\\\",\\\"local-name\\\":\\\"$name\\\"}}], default_flow_style=False)\" >> .rosinstall;"; done)ls -al; cat .rosinstall; wstool update"; export USE_DEB=false; fi; # set USE_DEB false to enable .travis.rosinstall
-script:
-  - if [ "${IS_EUSLISP_TRAVIS_TEST}" != "true" ] ; then export ROS_PARALLEL_JOBS="-j2 -l2" ; fi
-  - if [ "${ROS_DISTRO}" == "hydro" ] ; then sudo apt-get install -y --force-yes gdebi && wget https://bintray.com/artifact/download/furushchev/ros-shadow-fixed/python-catkin-tools_0.3.1-1_all.deb && wget https://bintray.com/artifact/download/furushchev/ros-shadow-fixed/python-catkin-pkg_0.2.10-1_all.deb && sudo gdebi -n -q python-catkin-pkg_0.2.10-1_all.deb && sudo gdebi -n -q python-catkin-tools_0.3.1-1_all.deb && sudo apt-mark hold python-catkin-tools; fi
   # Forcely upgrade PCRE to avoid failure in building hrpsys with hydro.
   # https://github.com/start-jsk/rtmros_common/issues/1076
   # .deb can be got from https://pkgs.org (e.g., https://pkgs.org/download/libpcre3)
   # libpcre3-dev requires the same version of libpcrecpp0
   - if [ "${ROS_DISTRO}" == "hydro" ] && [ "${USE_DEB}" != "true" ] ; then add_scr="wget archive.ubuntu.com/ubuntu/pool/main/p/pcre3/libpcre3_8.31-2ubuntu2_amd64.deb; wget archive.ubuntu.com/ubuntu/pool/main/p/pcre3/libpcrecpp0_8.31-2ubuntu2_amd64.deb; wget archive.ubuntu.com/ubuntu/pool/main/p/pcre3/libpcre3-dev_8.31-2ubuntu2_amd64.deb; sudo dpkg -i libpcre3_8.31-2ubuntu2_amd64.deb; sudo dpkg -i libpcrecpp0_8.31-2ubuntu2_amd64.deb; sudo dpkg -i libpcre3-dev_8.31-2ubuntu2_amd64.deb; sudo apt-mark hold libpcre3 libpcrecpp0 libpcre3-dev"; fi; if [ "${BEFORE_SCRIPT}" == "" ] ; then export BEFORE_SCRIPT=${add_scr}; else export BEFORE_SCRIPT="${BEFORE_SCRIPT}; ${add_scr}"; fi
+script:
+  - if [ "${IS_EUSLISP_TRAVIS_TEST}" != "true" ] ; then export ROS_PARALLEL_JOBS="-j2 -l2" ; fi
+  - if [ "${ROS_DISTRO}" == "hydro" ] ; then sudo apt-get install -y --force-yes gdebi && wget https://bintray.com/artifact/download/furushchev/ros-shadow-fixed/python-catkin-tools_0.3.1-1_all.deb && wget https://bintray.com/artifact/download/furushchev/ros-shadow-fixed/python-catkin-pkg_0.2.10-1_all.deb && sudo gdebi -n -q python-catkin-pkg_0.2.10-1_all.deb && sudo gdebi -n -q python-catkin-tools_0.3.1-1_all.deb && sudo apt-mark hold python-catkin-tools; fi
   - if [ "${TEST_TYPE}" == "" ] ; then source .travis/travis.sh; else source ./.travis_test.sh ; fi
   - ccache -s
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,11 @@ before_script:
 script:
   - if [ "${IS_EUSLISP_TRAVIS_TEST}" != "true" ] ; then export ROS_PARALLEL_JOBS="-j2 -l2" ; fi
   - if [ "${ROS_DISTRO}" == "hydro" ] ; then sudo apt-get install -y --force-yes gdebi && wget https://bintray.com/artifact/download/furushchev/ros-shadow-fixed/python-catkin-tools_0.3.1-1_all.deb && wget https://bintray.com/artifact/download/furushchev/ros-shadow-fixed/python-catkin-pkg_0.2.10-1_all.deb && sudo gdebi -n -q python-catkin-pkg_0.2.10-1_all.deb && sudo gdebi -n -q python-catkin-tools_0.3.1-1_all.deb && sudo apt-mark hold python-catkin-tools; fi
+  # Forcely upgrade PCRE to avoid failure in building hrpsys with hydro.
+  # https://github.com/start-jsk/rtmros_common/issues/1076
+  # .deb can be got from https://pkgs.org (e.g., https://pkgs.org/download/libpcre3)
+  # libpcre3-dev requires the same version of libpcrecpp0
+  - if [ "${ROS_DISTRO}" == "hydro" ] && [ "${USE_DEB}" != "true" ] ; then wget archive.ubuntu.com/ubuntu/pool/main/p/pcre3/libpcre3_8.31-2ubuntu2_amd64.deb && wget archive.ubuntu.com/ubuntu/pool/main/p/pcre3/libpcrecpp0_8.31-2ubuntu2_amd64.deb && wget archive.ubuntu.com/ubuntu/pool/main/p/pcre3/libpcre3-dev_8.31-2ubuntu2_amd64.deb && sudo dpkg -i libpcre3_8.31-2ubuntu2_amd64.deb && sudo dpkg -i libpcrecpp0_8.31-2ubuntu2_amd64.deb && sudo dpkg -i libpcre3-dev_8.31-2ubuntu2_amd64.deb && sudo apt-mark hold libpcre3 libpcrecpp0 libpcre3-dev; fi
   - if [ "${TEST_TYPE}" == "" ] ; then source .travis/travis.sh; else source ./.travis_test.sh ; fi
   - ccache -s
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ script:
   # https://github.com/start-jsk/rtmros_common/issues/1076
   # .deb can be got from https://pkgs.org (e.g., https://pkgs.org/download/libpcre3)
   # libpcre3-dev requires the same version of libpcrecpp0
-  - if [ "${ROS_DISTRO}" == "hydro" ] && [ "${USE_DEB}" != "true" ] ; then export BEFORE_SCRIPT="wget archive.ubuntu.com/ubuntu/pool/main/p/pcre3/libpcre3_8.31-2ubuntu2_amd64.deb && wget archive.ubuntu.com/ubuntu/pool/main/p/pcre3/libpcrecpp0_8.31-2ubuntu2_amd64.deb && wget archive.ubuntu.com/ubuntu/pool/main/p/pcre3/libpcre3-dev_8.31-2ubuntu2_amd64.deb && sudo dpkg -i libpcre3_8.31-2ubuntu2_amd64.deb && sudo dpkg -i libpcrecpp0_8.31-2ubuntu2_amd64.deb && sudo dpkg -i libpcre3-dev_8.31-2ubuntu2_amd64.deb && sudo apt-mark hold libpcre3 libpcrecpp0 libpcre3-dev"; fi
+  - if [ "${ROS_DISTRO}" == "hydro" ] && [ "${USE_DEB}" != "true" ] ; then export BEFORE_SCRIPT="wget archive.ubuntu.com/ubuntu/pool/main/p/pcre3/libpcre3_8.31-2ubuntu2_amd64.deb; wget archive.ubuntu.com/ubuntu/pool/main/p/pcre3/libpcrecpp0_8.31-2ubuntu2_amd64.deb; wget archive.ubuntu.com/ubuntu/pool/main/p/pcre3/libpcre3-dev_8.31-2ubuntu2_amd64.deb; sudo dpkg -i libpcre3_8.31-2ubuntu2_amd64.deb; sudo dpkg -i libpcrecpp0_8.31-2ubuntu2_amd64.deb; sudo dpkg -i libpcre3-dev_8.31-2ubuntu2_amd64.deb; sudo apt-mark hold libpcre3 libpcrecpp0 libpcre3-dev"; fi
   - if [ "${TEST_TYPE}" == "" ] ; then source .travis/travis.sh; else source ./.travis_test.sh ; fi
   - ccache -s
 after_success:

--- a/setup_upstream.sh
+++ b/setup_upstream.sh
@@ -71,9 +71,9 @@ if [ "${ROS_DISTRO}" == "hydro" ] ; then
     # https://github.com/ros/robot_model/pull/105, https://github.com/ros/robot_model/pull/106, https://github.com/ros/robot_model/pull/108
     cat <<EOF >> /tmp/rosinstall.$$
 - git:
-    uri: https://github.com/ros/robot_model.git
+    uri: https://github.com/pazeshun/robot_model.git
     local-name: robot_model
-    version: 6534424
+    version: for-hydro-with-new-pcre
 EOF
 fi
 

--- a/setup_upstream.sh
+++ b/setup_upstream.sh
@@ -64,6 +64,19 @@ cat <<EOF >> /tmp/rosinstall.$$
     local-name: hrpsys
 EOF
 
+if [ "${ROS_DISTRO}" == "hydro" ] ; then
+    # As .travis.yml forcely upgrade PCRE to avoid failure in building hrpsys with hydro, hrpsys_state_publisher dies:
+    # https://github.com/start-jsk/rtmros_common/pull/1077#issuecomment-552102475
+    # To avoid this, the following PRs are required:
+    # https://github.com/ros/robot_model/pull/105, https://github.com/ros/robot_model/pull/106, https://github.com/ros/robot_model/pull/108
+    cat <<EOF >> /tmp/rosinstall.$$
+- git:
+    uri: https://github.com/ros/robot_model.git
+    local-name: robot_model
+    version: 6534424
+EOF
+fi
+
 wstool merge /tmp/rosinstall.$$ -t $WORKSPACE/src
 wstool info -t $WORKSPACE/src
 wstool update --abort-changed-uris -t $WORKSPACE/src $PACKAGE

--- a/setup_upstream.sh
+++ b/setup_upstream.sh
@@ -64,19 +64,6 @@ cat <<EOF >> /tmp/rosinstall.$$
     local-name: hrpsys
 EOF
 
-if [ "${ROS_DISTRO}" == "hydro" ] ; then
-    # As .travis.yml forcely upgrade PCRE to avoid failure in building hrpsys with hydro, hrpsys_state_publisher dies:
-    # https://github.com/start-jsk/rtmros_common/pull/1077#issuecomment-552102475
-    # To avoid this, the following PRs are required:
-    # https://github.com/ros/robot_model/pull/105, https://github.com/ros/robot_model/pull/106, https://github.com/ros/robot_model/pull/108
-    cat <<EOF >> /tmp/rosinstall.$$
-- git:
-    uri: https://github.com/pazeshun/robot_model.git
-    local-name: robot_model
-    version: for-hydro-with-new-pcre
-EOF
-fi
-
 wstool merge /tmp/rosinstall.$$ -t $WORKSPACE/src
 wstool info -t $WORKSPACE/src
 wstool update --abort-changed-uris -t $WORKSPACE/src $PACKAGE


### PR DESCRIPTION
Updated version of #1077 
- For indigo and melodic
  - Update .travis to jsk_travis 0.5.6 for indigo test & avoiding long log
    - Fix https://github.com/start-jsk/rtmros_common/pull/1077#issuecomment-549630031
    - Fix https://github.com/start-jsk/rtmros_common/pull/1077#issuecomment-549629846
- For hydro
  - Forcely upgrade PCRE to avoid failure in building hrpsys with hydro
    - Fix #1076 
  - Avoid robot_state_publisher failure when PCRE is upgraded
    - https://github.com/ros/robot_model/pull/105 + https://github.com/ros/robot_model/pull/106 + https://github.com/ros/robot_model/pull/108
    - See https://github.com/start-jsk/rtmros_common/pull/1077#issuecomment-552102475 and https://github.com/start-jsk/rtmros_common/pull/1077#issuecomment-552116241