### PR TITLE
Remove travis test with rtmros_hrp2 & fix to update euslisp-docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ env:
     - USE_JENKINS=true ROS_DISTRO=indigo USE_DEB=false EXTRA_DEB="ros-indigo-hrpsys-ros-bridge ros-indigo-pr2eus" NOT_TEST_INSTALL=true TEST_PKGS="hrpsys_ros_bridge" IS_EUSLISP_TRAVIS_TEST=true
     - USE_TRAVIS=true TEST_TYPE=work_with_downstream  TEST_PACKAGE=hironx-ros-bridge ROS_DISTRO=indigo EXTRA_DEB="ros-indigo-roslint"
     - USE_TRAVIS=true TEST_TYPE=work_with_315_1_10    TEST_PACKAGE=hironx-ros-bridge ROS_DISTRO=indigo EXTRA_DEB="ros-indigo-roslint"
-    - USE_JENKINS=true ROS_DISTRO=hydro  USE_DEB=true  EXTRA_DEB="ros-hydro-pr2eus"
+    - USE_TRAVIS=true ROS_DISTRO=indigo USE_DEB=true EXTRA_DEB="ros-indigo-pr2eus" NOT_TEST_INSTALL=true IS_EUSLISP_TRAVIS_TEST=false  # For updating euslisp-docs (Must be USE_TRAVIS=true and IS_EUSLISP_TRAVIS_TEST=false. See after_success)
     - USE_JENKINS=true ROS_DISTRO=kinetic USE_DEB=true
     - USE_JENKINS=true ROS_DISTRO=kinetic USE_DEB=false NOT_TEST_INSTALL=true
     - USE_JENKINS=true ROS_DISTRO=kinetic USE_DEB=true EXTRA_DEB="ros-kinetic-hrpsys-ros-bridge ros-kinetic-pr2eus" NOT_TEST_INSTALL=true TEST_PKGS="hrpsys_ros_bridge" IS_EUSLISP_TRAVIS_TEST=true
@@ -56,7 +56,6 @@ notifications:
     on_failure: always #[always|never|change] # default: always
 before_script:
   - set -x
-  - if [ "${TRAVIS_SECURE_ENV_VARS}" == "true" ]; then openssl aes-256-cbc -K $encrypted_b79fc5843df3_key -iv $encrypted_b79fc5843df3_iv -in .secrets.tar.enc -out .secrets.tar -d; tar -C ~/ -xvf .secrets.tar; fi
   # Forcely upgrade PCRE to avoid failure in building hrpsys with hydro.
   # This has a side effect, and we need extra settings.
   # Issue detail: https://github.com/start-jsk/rtmros_common/issues/1076
@@ -75,5 +74,7 @@ script:
   - if [ "${TEST_TYPE}" == "" ] ; then source .travis/travis.sh; else source ./.travis_test.sh ; fi
   - ccache -s
 after_success:
-  - TRAVIS_JOB_SUBNUMBER="${TRAVIS_JOB_NUMBER##*.}"
-  - if [ "$TRAVIS_JOB_SUBNUMBER" == 9 -a "$TRAVIS_BRANCH" == "master" -a "${TRAVIS_SECURE_ENV_VARS}" == "true" ]; then ${CI_SOURCE_PATH}/.travis/upload-docs.sh; fi
+  - if [ "${TRAVIS_SECURE_ENV_VARS}" == "true" ]; then openssl aes-256-cbc -K $encrypted_b79fc5843df3_key -iv $encrypted_b79fc5843df3_iv -in .secrets.tar.enc -out .secrets.tar -d; tar -C ~/ -xvf .secrets.tar; fi
+  # upload-docs.sh in after_success works only when jenkins is not used, because it assumes ~/ros/ws_rtmros_common/build exists on travis:
+  # https://github.com/jsk-ros-pkg/jsk_travis/blob/0.5.7/upload-docs.sh#L11
+  - if [ "${TRAVIS_BRANCH}" == "master" -a "${TRAVIS_SECURE_ENV_VARS}" == "true" -a "${USE_TRAVIS}" == "true" -a "${IS_EUSLISP_TRAVIS_TEST}" == "false" ]; then cd ${CI_SOURCE_PATH}; .travis/upload-docs.sh; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ env:
     - USE_JENKINS=true ROS_DISTRO=hydro  USE_DEB=true
     - USE_JENKINS=true ROS_DISTRO=hydro  USE_DEB=false   NOT_TEST_INSTALL=true
     - USE_JENKINS=true ROS_DISTRO=hydro  USE_DEB=source  NOT_TEST_INSTALL=true EXTRA_DEB="ros-hydro-roseus ros-hydro-euscollada ros-hydro-pr2eus" ROS_PARALLEL_JOBS="-j1 -l1" IS_EUSLISP_TRAVIS_TEST="true"
-    - USE_JENKINS=true ROS_DISTRO=hydro  USE_DEB=true    NOT_TEST_INSTALL=true INSTALL_SRC="http://github.com/start-jsk/rtmros_tutorials" TEST_PKGS="hrpsys_ros_bridge_tutorials" INSTALL_SRC_SECURE="git@github.com:start-jsk/rtmros_hrp2" TEST_PKGS_SECURE="jsk_hrp2_ros_bridge"
     - USE_JENKINS=true ROS_DISTRO=hydro  USE_DEB=source  NOT_TEST_INSTALL=true
     - USE_JENKINS=true ROS_DISTRO=hydro  USE_DEB=true    EXTRA_DEB="ros-hydro-hrpsys-ros-bridge ros-hydro-pr2eus" ROS_PARALLEL_JOBS="-j1 -l1" NOT_TEST_INSTALL=true IS_EUSLISP_TRAVIS_TEST="true"
     - USE_JENKINS=true ROS_DISTRO=hydro  USE_DEB=false   EXTRA_DEB="ros-hydro-hrpsys-ros-bridge ros-hydro-pr2eus" ROS_PARALLEL_JOBS="-j1 -l1" NOT_TEST_INSTALL=true IS_EUSLISP_TRAVIS_TEST="true"
@@ -57,9 +56,7 @@ notifications:
     on_failure: always #[always|never|change] # default: always
 before_script:
   - set -x
-  - if [ "${TRAVIS_SECURE_ENV_VARS}" == "true" ]; then openssl aes-256-cbc -K $encrypted_b79fc5843df3_key -iv $encrypted_b79fc5843df3_iv -in .secrets.tar.enc -out .secrets.tar -d; tar -C ~/ -xvf .secrets.tar; export INSTALL_SRC="$INSTALL_SRC $INSTALL_SRC_SECURE"; export TEST_PKGS="$TEST_PKGS $TEST_PKGS_SECURE"; fi
-  - export REPOSITORY_NAME=`basename $PWD`
-  - if [ "${INSTALL_SRC}" != "" ] ;then export sudo apt-get install python-yaml; export BEFORE_SCRIPT="$(for src in $INSTALL_SRC; do name=`basename $src`; echo "python -c \"import yaml;print yaml.dump([{\\\"git\\\":{\\\"uri\\\":\\\"$src\\\",\\\"local-name\\\":\\\"$name\\\"}}], default_flow_style=False)\" >> .rosinstall;"; done)ls -al; cat .rosinstall; wstool update"; export USE_DEB=false; fi; # set USE_DEB false to enable .travis.rosinstall
+  - if [ "${TRAVIS_SECURE_ENV_VARS}" == "true" ]; then openssl aes-256-cbc -K $encrypted_b79fc5843df3_key -iv $encrypted_b79fc5843df3_iv -in .secrets.tar.enc -out .secrets.tar -d; tar -C ~/ -xvf .secrets.tar; fi
   # Forcely upgrade PCRE to avoid failure in building hrpsys with hydro.
   # This has a side effect, and we need extra settings.
   # Issue detail: https://github.com/start-jsk/rtmros_common/issues/1076


### PR DESCRIPTION
This PR realizes the following two points, related to `TRAVIS_SECURE_ENV_VARS`.

### Remove travis test with rtmros_hrp2
See https://github.com/start-jsk/rtmros_hrp2/pull/548 for details

### Fix to update euslisp-docs
.travis.yml in rtmros_common has a setting to upload documentation of rtm-ros-robot-interface.l to [euslisp-docs](https://github.com/jsk-ros-pkg/euslisp-docs) (reflected to [Read the Docs page](https://euslisp-docs.readthedocs.io/en/latest/hrpsys_ros_bridge/rtm-ros-robot-interface/)): https://github.com/start-jsk/rtmros_common/blob/1.4.2/.travis.yml#L62 (this uses `TRAVIS_SECURE_ENV_VARS`)
However, this line currently doesn't work, because `$TRAVIS_JOB_SUBNUMBER" == 9` is satisfied in `USE_TRAVIS=true TEST_TYPE=work_with_315_1_10 TEST_PACKAGE=hironx-ros-bridge ROS_DISTRO=indigo EXTRA_DEB="ros-indigo-roslint"` job, which doesn't include roseus or generate euslisp documentation.
- [When $TRAVIS_JOB_SUBNUMBER" == 9 was committed](https://github.com/start-jsk/rtmros_common/commit/464c6d31110ae27b71705f9b61cf8b1ff91abc78), the 9th job was `ROS_DISTRO=hydro  USE_DEB=true  EXTRA_DEB="ros-hydro-pr2eus"`:https://github.com/start-jsk/rtmros_common/blob/464c6d31110ae27b71705f9b61cf8b1ff91abc78/.travis.yml#L32

To solve this problem, I added a new job with `EXTRA_DEB="ros-indigo-pr2eus"` and `IS_EUSLISP_TRAVIS_TEST=false`, instead of `ROS_DISTRO=hydro  USE_DEB=true  EXTRA_DEB="ros-hydro-pr2eus"`.
To upload euslisp documentation in that test, I used `${IS_EUSLISP_TRAVIS_TEST} == "false"` as the upload condition, instead of `TRAVIS_JOB_SUBNUMBER`.