### PR TITLE
[travis] Add `cd ${TRAVIS_BUILD_DIR}` before decryption, as current directory is changed after travis.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,7 +74,7 @@ script:
   - if [ "${TEST_TYPE}" == "" ] ; then source .travis/travis.sh; else source ./.travis_test.sh ; fi
   - ccache -s
 after_success:
-  - if [ "${TRAVIS_SECURE_ENV_VARS}" == "true" ]; then cd ${CI_SOURCE_PATH}; openssl aes-256-cbc -K $encrypted_b79fc5843df3_key -iv $encrypted_b79fc5843df3_iv -in .secrets.tar.enc -out .secrets.tar -d; tar -C ~/ -xvf .secrets.tar; fi
+  - if [ "${TRAVIS_SECURE_ENV_VARS}" == "true" ]; then cd ${TRAVIS_BUILD_DIR}; openssl aes-256-cbc -K $encrypted_b79fc5843df3_key -iv $encrypted_b79fc5843df3_iv -in .secrets.tar.enc -out .secrets.tar -d; tar -C ~/ -xvf .secrets.tar; fi
   # upload-docs.sh in after_success works only when jenkins is not used, because it assumes ~/ros/ws_rtmros_common/build exists on travis:
   # https://github.com/jsk-ros-pkg/jsk_travis/blob/0.5.7/upload-docs.sh#L11
-  - if [ "${TRAVIS_BRANCH}" == "master" -a "${TRAVIS_SECURE_ENV_VARS}" == "true" -a "${USE_TRAVIS}" == "true" -a "${IS_EUSLISP_TRAVIS_TEST}" == "false" ]; then cd ${CI_SOURCE_PATH}; .travis/upload-docs.sh; fi
+  - if [ "${TRAVIS_BRANCH}" == "master" -a "${TRAVIS_SECURE_ENV_VARS}" == "true" -a "${USE_TRAVIS}" == "true" -a "${IS_EUSLISP_TRAVIS_TEST}" == "false" ]; then cd ${TRAVIS_BUILD_DIR}; .travis/upload-docs.sh; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,7 +74,7 @@ script:
   - if [ "${TEST_TYPE}" == "" ] ; then source .travis/travis.sh; else source ./.travis_test.sh ; fi
   - ccache -s
 after_success:
-  - if [ "${TRAVIS_SECURE_ENV_VARS}" == "true" ]; then openssl aes-256-cbc -K $encrypted_b79fc5843df3_key -iv $encrypted_b79fc5843df3_iv -in .secrets.tar.enc -out .secrets.tar -d; tar -C ~/ -xvf .secrets.tar; fi
+  - if [ "${TRAVIS_SECURE_ENV_VARS}" == "true" ]; then cd ${CI_SOURCE_PATH}; openssl aes-256-cbc -K $encrypted_b79fc5843df3_key -iv $encrypted_b79fc5843df3_iv -in .secrets.tar.enc -out .secrets.tar -d; tar -C ~/ -xvf .secrets.tar; fi
   # upload-docs.sh in after_success works only when jenkins is not used, because it assumes ~/ros/ws_rtmros_common/build exists on travis:
   # https://github.com/jsk-ros-pkg/jsk_travis/blob/0.5.7/upload-docs.sh#L11
   - if [ "${TRAVIS_BRANCH}" == "master" -a "${TRAVIS_SECURE_ENV_VARS}" == "true" -a "${USE_TRAVIS}" == "true" -a "${IS_EUSLISP_TRAVIS_TEST}" == "false" ]; then cd ${CI_SOURCE_PATH}; .travis/upload-docs.sh; fi


### PR DESCRIPTION
I'm sorry, but I made a mistake around decryption in #1086.
(I couldn't debug this because decryption works on branches of original repositories...)

Decryption is moved from before_script to after_success in #1086 , because decrypted information is used only for upload-docs.sh in after_success.
However, current directory in after_success is `/home/travis/ros/ws_rtmros_common`, while `/home/travis/build/start-jsk/rtmros_common` in before_script.
`.secrets.tar.enc` used in decryption is not in `/home/travis/ros/ws_rtmros_common`, so decryption failed.
(See https://travis-ci.org/start-jsk/rtmros_common/jobs/628512639)

~~To fix that, this PR adds `cd ${CI_SOURCE_PATH}` ([${CI_SOURCE_PATH} is set to /home/travis/build/start-jsk/rtmros_common in travis.sh](https://github.com/jsk-ros-pkg/jsk_travis/blob/0.5.7/travis.sh#L30)) before decryption.~~
To fix that, this PR adds `cd ${TRAVIS_BUILD_DIR}` before decryption ([${TRAVIS_BUILD_DIR} is a default environment variable describing the initial directory of before_script](https://docs.travis-ci.com/user/environment-variables/#default-environment-variables)).