### PR TITLE
Adapt README for melodic & fix style of README & fix to run on melodic

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ This document explains how to use and how to contribute to rtm-ros-robotics soft
 
  rtm-ros-robotics software is distributed as ros-debian packages, if you already uses ROS system, install the software as follows:
  - `sudo apt-get install ros-${ROS_DISTRO}-rtmros-common`
- 
+
  **NOTE** Currently, those packages are not released to `melodic` distribution. Please compile all rtm-ros-robotics source code by following the section below ("2. Compile from source code").
- 
+
  If you did not installed ROS sysem, please follow [this instruction](http://wiki.ros.org/ROS/Installation).
  - ``sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu `lsb_release -a` main" > /etc/apt/sources.list.d/ros-latest.list'``
  - `wget http://packages.ros.org/ros.key -O - | sudo apt-key add -`
@@ -35,11 +35,11 @@ This document explains how to use and how to contribute to rtm-ros-robotics soft
  - `cd ~/catkin_ws/src`
  - `wstool init .`
  - `wstool set rtmros_common https://github.com/start-jsk/rtmros_common --git -y`
- 
+
  If compile all source code
  - `wstool merge https://raw.githubusercontent.com/start-jsk/rtmros_common/master/.travis.rosinstall -y`
  - `wstool merge https://raw.githubusercontent.com/start-jsk/rtmros_common/master/.travis.rosinstall.${ROS_DISTRO} -y`
- 
+
  Both methods needs following procedures.
  - `wstool update`
  - `cd ..`

--- a/README.md
+++ b/README.md
@@ -14,38 +14,39 @@ This document explains how to use and how to contribute to rtm-ros-robotics soft
 1. Install software
 
  rtm-ros-robotics software is distributed as ros-debian packages, if you already uses ROS system, install the software as follows:
- - `sudo apt-get install ros-$ROS_DISTRO-rtmros-common`
+ - `sudo apt-get install ros-${ROS_DISTRO}-rtmros-common`
  
- If you did not installed ROS sysem, please follow [this instruction](http://wiki.ros.org/hydro/Installation/Ubuntu).
+ **NOTE** Currently, those packages are not released to `melodic` distribution. Please compile all rtm-ros-robotics source code by following the section below ("2. Compile from source code").
+ 
+ If you did not installed ROS sysem, please follow [this instruction](http://wiki.ros.org/ROS/Installation).
  - ``sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu `lsb_release -a` main" > /etc/apt/sources.list.d/ros-latest.list'``
  - `wget http://packages.ros.org/ros.key -O - | sudo apt-key add -`
  - `sudo apt-get update`
- - `sudo apt-get update ros-hydro-base` # you may use ros-groovy-base if you want
+ - `sudo apt-get update ros-${ROS_DISTRO}-base`
  - `sudo rosdep init`
  - `rosdep update`
- - `source /opt/ros/hydro/setup.bash` # it is better to source ROS environment everytime terminal starts (`echo "source /opt/ros/hydro/setup.bash" >> ~/.bashrc`)
+ - `source /opt/ros/${ROS_DISTRO}/setup.bash` # it is better to source ROS environment everytime terminal starts (`echo "source /opt/ros/${ROS_DISTRO}/setup.bash" >> ~/.bashrc`)
 
 2. Compile from source code
 
- You may have two choice, one is to compile all rtm-ros-robotics source code, other is to compile target repository.
- First, create catkin workspace
+ You may have two choices, one is to compile target repository (rtmros_common) only, the other is to compile all rtm-ros-robotics source code.
+ First, create catkin workspace and add rtmros_common
  - `mkdir -p ~/catkin_ws/src`
  - `cd ~/catkin_ws/src`
- - `catkin_init_workspace`
  - `wstool init .`
+ - `wstool set rtmros_common https://github.com/start-jsk/rtmros_common --git -y`
  
  If compile all source code
- - `wstool merge https://raw.github.com/start-jsk/rtmros_common/master/.rosinstall -y`
- 
- Else if compile only targe repository
- - `wstool set rtm-ros-robotics/rtmros_common https://github.com/start-jsk/rtmros_common --git -y`
+ - `wstool merge https://raw.githubusercontent.com/start-jsk/rtmros_common/master/.travis.rosinstall -y`
+ - `wstool merge https://raw.githubusercontent.com/start-jsk/rtmros_common/master/.travis.rosinstall.${ROS_DISTRO} -y`
  
  Both methods needs following procedures.
- - `wstool update `
+ - `wstool update`
  - `cd ..`
- - `source /opt/ros/hydro/setup.bash`
- - `rosdep install -v -r --from-paths src --ignore-src --rosdistro hydro -y`
- - `catkin_make`
+ - `source /opt/ros/${ROS_DISTRO}/setup.bash`
+ - `rosdep install -r --from-paths src --ignore-src -y`
+ - `sudo apt-get install python-catkin-tools`
+ - `catkin build`
 
 3. Contributes to rtm-ros-robotics projects.
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,8 @@
-================================================================================================================================================================
-rtmros_common  [![Build Status](https://travis-ci.org/start-jsk/rtmros_common.png)](https://travis-ci.org/start-jsk/rtmros_common)
-================================================================================================================================================================
+# rtmros_common  [![Build Status](https://travis-ci.org/start-jsk/rtmros_common.png)](https://travis-ci.org/start-jsk/rtmros_common)
 
 A package suite that provides all the capabilities for the ROS users to connect to the robots that run on RT Middleware or RTM-based controllers.
 
-.. contents::
-
-Install
-========
+## Install
 
 This document explains how to use and how to contribute to rtm-ros-robotics softwares ([openrtm_aist_core](https://github.com/start-jsk/openrtm_aist_core), [openhrp3](https://github.com/start-jsk/openhrp3), [hrpsys](https://github.com/start-jsk/hrpsys), [rtshell_core](https://github.com/start-jsk/rtshell_core), [rtmros_common](https://github.com/start-jsk/rtmros_common), [rtmros_hironx](https://github.com/start-jsk/rtmros_hironx), [rtmros_tutorial](https://github.com/start-jsk/rtmros_turorial), [rtmros_gazebo](https://github.com/start-jsk/rtmros_gazebo)). The instruction uses `rtmros_common` repository as an example, but also works for other rtm-ros-robotics repositories.
 
@@ -77,39 +72,36 @@ before you use them.
  - Merge those remote branch into your current branch
  - `git merge <awesome-fork>/<branch-name>`
 
-For maintainers
-===============
+## For maintainers
 
-Tweak to release into Groovy
---------------------------------
+### Tweak to release into Groovy
 
 While in current design the package depends on `pr2_controllers_msgs <http://wiki.ros.org/pr2_controllers_msgs>`_ that's catkinized from ROS hydro onward and not available in ROS groovy, some hacks allow the package not to separate `branches` (regardless it's good or not, doing so is the decision as of March 2014). This requires another hack during release process using `bloom` as follows:
 
  1. Run `bloom <http://wiki.ros.org/bloom>`_ as normal. E.g. `$ bloom-release --rosdistro groovy --track groovy rtmros_common`.
  2. Once `bloom` halts and its command prompt starts waiting on the same terminal (the output might look as following), edit `package.xml` to comment out lines for declaring build and run depend on `pr2-controllers`.
 
-  ::
-
+    ```
     $ bloom-release --rosdistro groovy --track groovy rtmros_common
     :
     >>> Resolve any conflicts and when you have resolved this problem run 'git am --resolved' and then exit the shell using 'exit 0'. <<<
         To abort use 'exit 1'
-    (bloom)emacs package.xml 
+    (bloom)emacs package.xml
+    ```
 
-  Modify `package.xml` as:
+    Modify `package.xml` as:
 
-  ::
-
-    :  
+    ```
+    :
     <!-- <build_depend>pr2_controllers</build_depend> -->
     :
     <!-- <run_depend>pr2_controllers</run_depend> -->
     :
+    ```
 
  3. Run `git add`, `$ git am --skip`, `git commit` like below, and `exit 0` respectively. If all succeeds then `bloom` resumes.
 
-  ::
-
+    ```
     (bloom)git add package.xml
     (bloom)git am --skip
     Resolve operation not in progress, we are not resuming.
@@ -127,3 +119,4 @@ While in current design the package depends on `pr2_controllers_msgs <http://wik
      [git-bloom-patch import]: Applied 2 patches
     :
     (bloom continues)
+    ```

--- a/hrpsys_ros_bridge/scripts/collision_state.py
+++ b/hrpsys_ros_bridge/scripts/collision_state.py
@@ -15,6 +15,7 @@ import os
 import rtm
 
 from hrpsys import hrpsys_config
+from hrpsys import ModelLoader_idl
 import OpenHRP
 
 import socket
@@ -63,7 +64,7 @@ def rtc_init () :
     if modelfile:
         import CosNaming
         obj = rtm.rootnc.resolve([CosNaming.NameComponent('ModelLoader', '')])
-        mdlldr = obj._narrow(OpenHRP.ModelLoader_idl._0_OpenHRP__POA.ModelLoader)
+        mdlldr = obj._narrow(ModelLoader_idl._0_OpenHRP__POA.ModelLoader)
         rospy.loginfo("  bodyinfo URL = file://"+modelfile)
         body_info = mdlldr.getBodyInfo("file://"+modelfile)
         root_link_name = body_info._get_links()[0].segments[0].name


### PR DESCRIPTION
This PR adds the procedure of installing rtmros_common in melodic to README.
I confirmed this procedure works by running `rtmlaunch hrpsys_ros_bridge samplerobot.launch` after that procedure.
Following simulator correctly brings up:
![Screenshot from 2020-04-03 00-25-22](https://user-images.githubusercontent.com/14994939/78267191-a59bda00-7541-11ea-8371-06a9e4c00522.png)

Also, this PR fixes style of README.md to markdown.
#530 introduced rst style to README.md, but that file is markdown.
@130s Did you have any specific reason to use rst style?
If so, I'll delete the style fixing commit.