### PR TITLE
Use latest hrpsys when hrpsys is built on kinetic, in case libpcl-dev and libopenni2-dev exist

### DIFF
--- a/.travis.rosinstall.kinetic
+++ b/.travis.rosinstall.kinetic
@@ -2,7 +2,14 @@
     uri: https://github.com/tork-a/openhrp3-release
     version: release/kinetic/openhrp3
     local-name: openhrp3
+# We want to use source of released hrpsys, but building it fails when libpcl-dev and libopenni2-dev exist.
+# Waiting for https://github.com/fkanehiro/hrpsys-base/pull/1242 to be released.
+# Details: https://github.com/start-jsk/rtmros_common/pull/1090#issuecomment-610860446
+# - git:
+#     uri: https://github.com/tork-a/hrpsys-release
+#     version: release/kinetic/hrpsys
+#     local-name: hrpsys
 - git:
-    uri: https://github.com/tork-a/hrpsys-release
-    version: release/kinetic/hrpsys
+    uri: https://github.com/fkanehiro/hrpsys-base
+    version: master
     local-name: hrpsys

--- a/.travis.rosinstall.kinetic
+++ b/.travis.rosinstall.kinetic
@@ -5,6 +5,8 @@
 # We want to use source of released hrpsys, but building it fails when libpcl-dev and libopenni2-dev exist.
 # Waiting for https://github.com/fkanehiro/hrpsys-base/pull/1242 to be released.
 # Details: https://github.com/start-jsk/rtmros_common/pull/1090#issuecomment-610860446
+# Don't forget to remove libopencv-dev installation from .travis.yml and README when using hrpsys-release again.
+# Details: https://github.com/start-jsk/rtmros_common/pull/1091#issuecomment-611457804
 # - git:
 #     uri: https://github.com/tork-a/hrpsys-release
 #     version: release/kinetic/hrpsys

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ env:
     - USE_TRAVIS=true ROS_DISTRO=indigo USE_DEB=true EXTRA_DEB="ros-indigo-pr2eus" NOT_TEST_INSTALL=true IS_EUSLISP_TRAVIS_TEST=false  # For updating euslisp-docs (Must be USE_TRAVIS=true and IS_EUSLISP_TRAVIS_TEST=false. See after_success)
     - USE_JENKINS=true ROS_DISTRO=kinetic USE_DEB=true
     - USE_JENKINS=true ROS_DISTRO=kinetic USE_DEB=false NOT_TEST_INSTALL=true
+    - USE_JENKINS=true ROS_DISTRO=kinetic USE_DEB=false EXTRA_DEB="libopenni2-dev libpcl-dev" NOT_TEST_INSTALL=true  # To catch https://github.com/start-jsk/rtmros_common/pull/1090#issuecomment-610860446
     - USE_JENKINS=true ROS_DISTRO=kinetic USE_DEB=true EXTRA_DEB="ros-kinetic-hrpsys-ros-bridge ros-kinetic-pr2eus" NOT_TEST_INSTALL=true TEST_PKGS="hrpsys_ros_bridge" IS_EUSLISP_TRAVIS_TEST=true
     - USE_JENKINS=true ROS_DISTRO=kinetic USE_DEB=false EXTRA_DEB="ros-kinetic-hrpsys-ros-bridge ros-kinetic-pr2eus" NOT_TEST_INSTALL=true TEST_PKGS="hrpsys_ros_bridge" IS_EUSLISP_TRAVIS_TEST=true
     - USE_JENKINS=true ROS_DISTRO=melodic USE_DEB=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,11 @@ notifications:
     on_failure: always #[always|never|change] # default: always
 before_script:
   - set -x
+  # Install libopencv-dev manually to compile hrpsys-simulator in hrpsys-base on kinetic
+  # Details: https://github.com/start-jsk/rtmros_common/pull/1091#issuecomment-611457804
+  #          https://github.com/start-jsk/rtmros_common/pull/1091#issuecomment-611476618
+  # Waiting for .travis.rosinstall.kinetic to use hrpsys-release
+  - if [ "${ROS_DISTRO}" == "kinetic" ] && [ "${USE_DEB}" != "true" ] ; then if [ "${EXTRA_DEB}" == "" ] ; then export EXTRA_DEB="libopencv-dev"; else export EXTRA_DEB="${EXTRA_DEB} libopencv-dev"; fi; fi
   # Forcely upgrade PCRE to avoid failure in building hrpsys with hydro.
   # This has a side effect, and we need extra settings.
   # Issue detail: https://github.com/start-jsk/rtmros_common/issues/1076

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ This document explains how to use and how to contribute to rtm-ros-robotics soft
 
  If you want to compile all source code:
  - (If the target repository is not `rtmros_common`) `wstool set rtmros_common https://github.com/start-jsk/rtmros_common --git -y`
+ - (On `kinetic` distribution) `sudo apt-get install libopencv-dev`
+   - Skipping this may cause [runtime error](https://github.com/start-jsk/rtmros_common/pull/1091#issuecomment-611457804)
  - `wstool merge https://raw.githubusercontent.com/start-jsk/rtmros_common/master/.travis.rosinstall -y`
  - `wstool merge https://raw.githubusercontent.com/start-jsk/rtmros_common/master/.travis.rosinstall.${ROS_DISTRO} -y`
    - Please ignore `Unable to download URL` error on `indigo` distribution

--- a/README.md
+++ b/README.md
@@ -4,38 +4,40 @@ A package suite that provides all the capabilities for the ROS users to connect 
 
 ## Install
 
-This document explains how to use and how to contribute to rtm-ros-robotics softwares ([openrtm_aist_core](https://github.com/start-jsk/openrtm_aist_core), [openhrp3](https://github.com/start-jsk/openhrp3), [hrpsys](https://github.com/start-jsk/hrpsys), [rtshell_core](https://github.com/start-jsk/rtshell_core), [rtmros_common](https://github.com/start-jsk/rtmros_common), [rtmros_hironx](https://github.com/start-jsk/rtmros_hironx), [rtmros_tutorial](https://github.com/start-jsk/rtmros_turorial), [rtmros_gazebo](https://github.com/start-jsk/rtmros_gazebo)). The instruction uses `rtmros_common` repository as an example, but also works for other rtm-ros-robotics repositories.
+This document explains how to use and how to contribute to rtm-ros-robotics software ([openrtm_aist_core](https://github.com/start-jsk/openrtm_aist_core), [openhrp3](https://github.com/start-jsk/openhrp3), [hrpsys](https://github.com/start-jsk/hrpsys), [rtshell_core](https://github.com/start-jsk/rtshell_core), [rtmros_common](https://github.com/start-jsk/rtmros_common), [rtmros_hironx](https://github.com/start-jsk/rtmros_hironx), [rtmros_tutorial](https://github.com/start-jsk/rtmros_turorial), [rtmros_gazebo](https://github.com/start-jsk/rtmros_gazebo)). The instruction uses `rtmros_common` repository as an example, but also works for other rtm-ros-robotics repositories.
 
 1. Install software
 
- rtm-ros-robotics software is distributed as ros-debian packages, if you already uses ROS system, install the software as follows:
+ rtm-ros-robotics software is distributed as ros-debian packages, if you already use ROS system, install the software as follows:
  - `sudo apt-get install ros-${ROS_DISTRO}-rtmros-common`
 
  **NOTE** Currently, those packages are not released to `melodic` distribution. Please compile all rtm-ros-robotics source code by following the section below ("2. Compile from source code").
 
- If you did not installed ROS sysem, please follow [this instruction](http://wiki.ros.org/ROS/Installation).
+ If you did not install ROS system, please follow [this instruction](http://wiki.ros.org/ROS/Installation).
  - ``sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu `lsb_release -a` main" > /etc/apt/sources.list.d/ros-latest.list'``
  - `wget http://packages.ros.org/ros.key -O - | sudo apt-key add -`
  - `sudo apt-get update`
  - `sudo apt-get update ros-${ROS_DISTRO}-base`
  - `sudo rosdep init`
  - `rosdep update`
- - `source /opt/ros/${ROS_DISTRO}/setup.bash` # it is better to source ROS environment everytime terminal starts (`echo "source /opt/ros/${ROS_DISTRO}/setup.bash" >> ~/.bashrc`)
+ - `source /opt/ros/${ROS_DISTRO}/setup.bash` # it is better to source ROS environment every time terminal starts (`echo "source /opt/ros/${ROS_DISTRO}/setup.bash" >> ~/.bashrc`)
 
 2. Compile from source code
 
  You may have two choices, one is to compile target repository (rtmros_common) only, the other is to compile all rtm-ros-robotics source code.
- First, create catkin workspace and add rtmros_common
+ First, create catkin workspace and add rtmros_common:
  - `mkdir -p ~/catkin_ws/src`
  - `cd ~/catkin_ws/src`
  - `wstool init .`
  - `wstool set rtmros_common https://github.com/start-jsk/rtmros_common --git -y`
 
- If compile all source code
+ If you want to compile all source code:
+ - (If the target repository is not `rtmros_common`) `wstool set rtmros_common https://github.com/start-jsk/rtmros_common --git -y`
  - `wstool merge https://raw.githubusercontent.com/start-jsk/rtmros_common/master/.travis.rosinstall -y`
  - `wstool merge https://raw.githubusercontent.com/start-jsk/rtmros_common/master/.travis.rosinstall.${ROS_DISTRO} -y`
+   - Please ignore `Unable to download URL` error on `indigo` distribution
 
- Both methods needs following procedures.
+ Both methods need following procedures:
  - `wstool update`
  - `cd ..`
  - `source /opt/ros/${ROS_DISTRO}/setup.bash`
@@ -43,34 +45,34 @@ This document explains how to use and how to contribute to rtm-ros-robotics soft
  - `sudo apt-get install python-catkin-tools`
  - `catkin build`
 
-3. Contributes to rtm-ros-robotics projects.
+3. Contribute to rtm-ros-robotics projects.
 
  - First fork the target repository on GitHub
- - Move to the package direcotry
- - `source ~/catkin_ws/devel/setup.bash`
- - `roscd rtmros_common`
- -  create branch for your fix
- - `git checkout -b your_awesome_code_branch`
- -  write awesome code and commit to local repo
- -   ... wite code....
- - `git commit -m "detailed description of what you did"`
- -  Add your forked repository as upstream
- - `git remote add experimental https://github.com/<your github user name>/rtmros_common`
+ - Move to the package directory
+   - `source ~/catkin_ws/devel/setup.bash`
+   - `roscd rtmros_common`
+ - Create branch for your fix
+   - `git checkout -b your_awesome_code_branch`
+ - Write awesome code and commit to local repo
+   - ...Write code....
+   - `git commit -m "detailed description of what you did"`
+ - Add your forked repository as upstream
+   - `git remote add experimental https://github.com/<your github user name>/rtmros_common`
  - `git push experimental your_awesome_code_branch`
  - Submit a pull request on GitHub to the repository
- - Please check travic-ci status after sending your pull request.
+ - Please check travis-ci status after sending your pull request.
 
-4. Uses other forked repository *before* merged into master.
+4. Use other forked repository *before* merged into master.
 
 You don't need to wait for the maintainers to merge some pull requests by others
 before you use them.
 
  - Adding other's remote repository to your git remote
- - `git remote add <awesome-fork> https://github.com/<user>/rtmros_common`
+   - `git remote add <awesome-fork> https://github.com/<user>/rtmros_common`
  - Fetch branches from the remote.
- - `git fetch <awesome-fork>`
+   - `git fetch <awesome-fork>`
  - Merge those remote branch into your current branch
- - `git merge <awesome-fork>/<branch-name>`
+   - `git merge <awesome-fork>/<branch-name>`
 
 ## For maintainers
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A package suite that provides all the capabilities for the ROS users to connect 
 
 ## Install
 
-This document explains how to use and how to contribute to rtm-ros-robotics software ([openrtm_aist_core](https://github.com/start-jsk/openrtm_aist_core), [openhrp3](https://github.com/start-jsk/openhrp3), [hrpsys](https://github.com/start-jsk/hrpsys), [rtshell_core](https://github.com/start-jsk/rtshell_core), [rtmros_common](https://github.com/start-jsk/rtmros_common), [rtmros_hironx](https://github.com/start-jsk/rtmros_hironx), [rtmros_tutorial](https://github.com/start-jsk/rtmros_turorial), [rtmros_gazebo](https://github.com/start-jsk/rtmros_gazebo)). The instruction uses `rtmros_common` repository as an example, but also works for other rtm-ros-robotics repositories.
+This document explains how to use and how to contribute to rtm-ros-robotics software ([openrtm_aist](https://github.com/tork-a/openrtm_aist-release), [openhrp3](https://github.com/fkanehiro/openhrp3), [hrpsys](https://github.com/fkanehiro/hrpsys-base), [rtshell](https://github.com/tork-a/rtshell-release), [rtctree](https://github.com/tork-a/rtctree-release), [rtsprofile](https://github.com/tork-a/rtsprofile-release), [rtmros_common](https://github.com/start-jsk/rtmros_common), [rtmros_hironx](https://github.com/start-jsk/rtmros_hironx), [rtmros_tutorials](https://github.com/start-jsk/rtmros_tutorials), [rtmros_gazebo](https://github.com/start-jsk/rtmros_gazebo)). The instruction uses `rtmros_common` repository as an example, but also works for other rtm-ros-robotics repositories.
 
 1. Install software
 


### PR DESCRIPTION
Includes #1092 

We want to use source of released hrpsys, but building it fails on kinetic when libpcl-dev and libopenni2-dev exist.
Until https://github.com/fkanehiro/hrpsys-base/pull/1242 is released on kinetic, we have to use latest hrpsys on kinetic.
Details: https://github.com/start-jsk/rtmros_common/pull/1090#issuecomment-610860446

Also, I found some typos in README which I overlooked at #1090 , so this PR fixes them and format README.
Sorry for overlooking.