### PR TITLE
Remove released packages & use right branch in .travis.rosinstall.melodic

### DIFF
--- a/.travis.rosinstall.melodic
+++ b/.travis.rosinstall.melodic
@@ -6,12 +6,3 @@
     uri: https://github.com/fkanehiro/hrpsys-base
     version: master
     local-name: hrpsys
-- git:
-    uri: https://github.com/tork-a/rtshell-release
-    local-name: rtshell
-- git:
-    uri: https://github.com/tork-a/rtsprofile-release
-    local-name: rtsprofile
-- git:
-    uri: https://github.com/tork-a/rtctree-release
-    local-name: rtctree

--- a/.travis.rosinstall.melodic
+++ b/.travis.rosinstall.melodic
@@ -1,6 +1,6 @@
 - git:
     uri: https://github.com/tork-a/openhrp3-release
-    version: release/kinetic/openhrp3
+    version: release/melodic/openhrp3
     local-name: openhrp3
 - git:
     uri: https://github.com/fkanehiro/hrpsys-base


### PR DESCRIPTION
At the time of https://github.com/start-jsk/rtmros_common/commit/907636af6f33793e151a1a98d4a9784484861e46, `rtshell`, `rtsprofile`, and `rtctree` are not released on melodic.
Now they are released, so we can remove them from `.travis.rosinstall.melodic`.
I'm sorry for the fact that I didn't notice this at #1090 .

Also, this PR fixes to use the right branch of `openhrp3` for melodic.
However, this branch has a problem, so this PR waits for fixing it:
https://github.com/fkanehiro/openhrp3/pull/126#issuecomment-612048049