### PR TITLE
[hrpsys_ros_bridge_tutorials] Enable to call :def-limb-controller-method before *ri* initialization

### DIFF
--- a/hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l
+++ b/hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l
@@ -314,7 +314,7 @@
                       (cons :controller-action ,(format nil "~A_controller/follow_joint_trajectory_action" (string-downcase limb)))
                       (cons :controller-state ,(format nil "~A_controller/state" (string-downcase limb)))
                       (cons :action-type control_msgs::FollowJointTrajectoryAction)
-                      (cons :joint-names (list ,@(send-all (send robot limb :joint-list) :name))))
+                      (cons :joint-names (send-all (send robot ,limb :joint-list) :name)))
                      )))))
       (if debugp
           (pprint (macroexpand sexp)))

--- a/hrpsys_ros_bridge/test/hrpsys-samples/test-def-limb-controller-method.l
+++ b/hrpsys_ros_bridge/test/hrpsys-samples/test-def-limb-controller-method.l
@@ -1,0 +1,21 @@
+(require :unittest "lib/llib/unittest.l")
+(load "package://hrpsys_ros_bridge/euslisp/samplerobot-interface.l")
+
+(init-unit-test)
+
+;; Wait until Ros bridges are prepared.
+(ros::roseus "unittest")
+(unless (boundp '*tfl*)
+  (defvar *tfl* (instance ros::transform-listener :init)))
+(send *tfl* :wait-for-transform "WAIST_LINK0" "odom" (ros::time) 20.0)
+
+(deftest test-def-limb-controller-method
+  ;; Test :def-limb-controller-method before *ri* initialization
+  (assert (instance samplerobot-interface :def-limb-controller-method :rleg))
+  (samplerobot-init)
+  ;; Test :def-limb-controller-method after *ri* initialization
+  (assert (send *ri* :def-limb-controller-method :rleg))
+  )
+
+(run-all-tests)
+(exit)

--- a/hrpsys_ros_bridge/test/hrpsys-samples/test_samplerobot_euslisp_unittests.launch
+++ b/hrpsys_ros_bridge/test/hrpsys-samples/test_samplerobot_euslisp_unittests.launch
@@ -42,4 +42,8 @@
         args="$(find hrpsys_ros_bridge)/test/hrpsys-samples/samplerobot-unittest.l $(find hrpsys_ros_bridge)/test/hrpsys-samples/samplerobot-auto-balancer.l"
         time-limit="900"
         retry="1" />
+  <test test-name="test_def_limb_controller_method" pkg="roseus" type="roseus"
+        args="$(find hrpsys_ros_bridge)/test/hrpsys-samples/test-def-limb-controller-method.l"
+        time-limit="300"
+        retry="1" />
 </launch>


### PR DESCRIPTION
## Problem

Currently, some of [EusLisp interface in rtmros_tutorials](https://github.com/start-jsk/rtmros_tutorials/tree/34cd4d03556a6630c8e89058a24c96edd779edaa/hrpsys_ros_bridge_tutorials/euslisp) cannot be initialized with a partial controller (e.g., `:rarm-controller`):
```
$ roseus hironxjsk-interface.l 
configuring by "/opt/ros/kinetic/share/euslisp/jskeus/eus//lib/eusrt.l"
;; readmacro ;; object ;; packsym ;; common ;; constants ;; stream ;; string ;; loader ;; pprint ;; process ;; hashtab ;; array ;; mathtran ;; eusdebug ;; eusforeign ;; extnum ;; coordinates ;; tty ;; history ;; toplevel ;; trans ;; comp ;; builtins ;; par ;; intersection ;; geoclasses ;; geopack ;; geobody ;; primt ;; compose ;; polygon ;; viewing ;; viewport ;; viewsurface ;; hid ;; shadow ;; bodyrel ;; dda ;; helpsub ;; eushelp ;; xforeign ;; Xdecl ;; Xgraphics ;; Xcolor ;; Xeus ;; Xevent ;; Xpanel ;; Xitem ;; Xtext ;; Xmenu ;; Xscroll ;; Xcanvas ;; Xtop ;; Xapplwin 
connected to Xserver DISPLAY=:0
X events are being asynchronously monitored.
;; pixword ;; RGBHLS ;; convolve ;; piximage ;; pbmfile ;; image_correlation ;; oglforeign ;; gldecl ;; glconst ;; glforeign ;; gluconst ;; gluforeign ;; glxconst ;; glxforeign ;; eglforeign ;; eglfunc ;; glutil ;; gltexture ;; glprim ;; gleus ;; glview ;; toiv-undefined ;; fstringdouble irtmath irtutil irtc irtgeoc irtgraph ___time ___pgsql irtgeo euspqp pqp irtscene irtmodel irtdyna irtrobot irtsensor irtbvh irtcollada irtpointcloud irtx eusjpeg euspng png irtimage irtglrgb 
;; extending gcstack 0x48eb9d0[16374] --> 0x4d70ad0[32748] top=3d66
irtgl irtglc irtviewer 
EusLisp 9.27( 1.2.1) for Linux64 created on ip-172-30-1-63(Wed Feb 19 14:11:11 UTC 2020)
roseus ;; loading roseus("1.7.4") on euslisp((9.27 ip-172-30-1-63 Wed Feb 19 14:11:11 UTC 2020  1.2.1))
eustf roseus_c_util 
;; extending gcstack 0x4d70ad0[32738] --> 0x5c78ee0[65476] top=7ec4
1.irteusgl$ hironxjsk-init :type :rarm-controller
Call Stack (max depth: 20):
  0: at (send self ctype)
  1: at (mapcar #'(lambda (param) (let* ((controller-action (cdr (assoc :controller-action param))) (action-type (cdr (assoc :action-type param))) (action (instance controller-action-client :init self (if namespace (format nil "~A/~A" namespace controller-action) controller-action) action-type :groupname groupname))) (push action tmp-actions))) (send self ctype))
  2: at (cond (create-actions (mapcar #'(lambda (param) (let* ((controller-action (cdr (assoc :controller-action param))) (action-type (cdr (assoc :action-type param))) (action (instance controller-action-client :init self (if namespace (format nil "~A/~A" namespace controller-action) controller-action) action-type :groupname groupname))) (push action tmp-actions))) (send self ctype)) (setq tmp-actions (nreverse tmp-actions)) (dolist (action tmp-actions) (unless controller-timeout (ros::ros-warn "Waiting for actionlib interface forever because controller-timeout is nil")) (unless (and joint-action-enable (send action :wait-for-server controller-timeout)) (ros::ros-warn "~A is not respond, ~A-interface is disabled" action (send robot :name)) (ros::ros-warn "~C[3~CmStarting 'Kinematics Simulator'~C[0m" 27 49 27) (ros::ros-warn "~C[3~Cm (If you do not intend to start Kinematics Simulator, make sure that you can run 'rostopic info /~A/goal' and 'rostopic info /~A/cancel' and check whether Subscribers exists. If there is no Subscribers, please check joint_trajectory_action node.)~C[0m" 27 52 (send action :name) (send action :name) 27) (ros::ros-warn "~C[3~Cm (Please also check 'rostopic info /~A/feedback' and 'rostopic info /~A/result' and check whether Publishers exists. If there is no Publishers, please check joint_trajectory_action node.)~C[0m" 27 52 (send action :name) (send action :name) 27) (ros::ros-warn "~C[3~Cm (If joint_trajectory_action node already exists, you might have a network problem. Please make sure that you can run 'rosnode ping JOINT_TRAJECTORY_ACTION_SERVER_NODE_NAME' and 'rosnode ping ~A')~C[0m" 27 52 (ros::get-name) 27) (when joint-enable-check (setq joint-action-enable nil) (return)))) (dolist (param (send self ctype)) (let* ((controller-state (cdr (assoc :controller-state param))) (key (intern (string-upcase controller-state) *keyword-package*))) (ros::subscribe (if namespace (format nil "~A/~A" namespace controller-state) controller-state) control_msgs::jointtrajectorycontrollerstate #'send self :set-robot-state1 key :groupname groupname)))) (t (mapcar #'(lambda (param) (let* ((controller-action (cdr (assoc :controller-action param))) (action-type (cdr (assoc :action-type param))) (name (if namespace (format nil "~A/~A" namespace controller-action) controller-action)) action) (setq action (find-if #'(lambda (ac) (string= name (send ac :name))) controller-actions)) (if action (push action tmp-actions)))) (send self ctype)) (setq tmp-actions (nreverse tmp-actions))))
  3: at (let (tmp-actions) (cond (create-actions (mapcar #'(lambda (param) (let* ((controller-action (cdr (assoc :controller-action param))) (action-type (cdr (assoc :action-type param))) (action (instance controller-action-client :init self (if namespace (format nil "~A/~A" namespace controller-action) controller-action) action-type :groupname groupname))) (push action tmp-actions))) (send self ctype)) (setq tmp-actions (nreverse tmp-actions)) (dolist (action tmp-actions) (unless controller-timeout (ros::ros-warn "Waiting for actionlib interface forever because controller-timeout is nil")) (unless (and joint-action-enable (send action :wait-for-server controller-timeout)) (ros::ros-warn "~A is not respond, ~A-interface is disabled" action (send robot :name)) (ros::ros-warn "~C[3~CmStarting 'Kinematics Simulator'~C[0m" 27 49 27) (ros::ros-warn "~C[3~Cm (If you do not intend to start Kinematics Simulator, make sure that you can run 'rostopic info /~A/goal' and 'rostopic info /~A/cancel' and check whether Subscribers exists. If there is no Subscribers, please check joint_trajectory_action node.)~C[0m" 27 52 (send action :name) (send action :name) 27) (ros::ros-warn "~C[3~Cm (Please also check 'rostopic info /~A/feedback' and 'rostopic info /~A/result' and check whether Publishers exists. If there is no Publishers, please check joint_trajectory_action node.)~C[0m" 27 52 (send action :name) (send action :name) 27) (ros::ros-warn "~C[3~Cm (If joint_trajectory_action node already exists, you might have a network problem. Please make sure that you can run 'rosnode ping JOINT_TRAJECTORY_ACTION_SERVER_NODE_NAME' and 'rosnode ping ~A')~C[0m" 27 52 (ros::get-name) 27) (when joint-enable-check (setq joint-action-enable nil) (return)))) (dolist (param (send self ctype)) (let* ((controller-state (cdr (assoc :controller-state param))) (key (intern (string-upcase controller-state) *keyword-package*))) (ros::subscribe (if namespace (format nil "~A/~A" namespace controller-state) controller-state) control_msgs::jointtrajectorycontrollerstate #'send self :set-robot-state1 key :groupname groupname)))) (t (mapcar #'(lambda (param) (let* ((controller-action (cdr (assoc :controller-action param))) (action-type (cdr (assoc :action-type param))) (name (if namespace (format nil "~A/~A" namespace controller-action) controller-action)) action) (setq action (find-if #'(lambda (ac) (string= name (send ac :name))) controller-actions)) (if action (push action tmp-actions)))) (send self ctype)) (setq tmp-actions (nreverse tmp-actions)))) (setf (gethash ctype controller-table) tmp-actions) tmp-actions)
  4: at (send self :add-controller controller-type :joint-enable-check t :create-actions t)
  5: at (setq controller-actions (send self :add-controller controller-type :joint-enable-check t :create-actions t))
  6: at (apply #'send-message self (class . super) :init args)
  7: at (apply #'send-message self (class . super) :init args)
  8: at (apply #'send-message self (class . super) :init args)
  9: at (send-super* :init args)
  10: at (let ((#:prog12724 (send-super* :init args))) (progn (send self :define-all-rosbridge-srv-methods) (ros::subscribe "/motor_states" hrpsys_ros_bridge::motorstates #'send self :rtmros-motor-states-callback :groupname groupname) (mapcar #'(lambda (x) (ros::subscribe (format nil "/~A" (string-downcase x)) geometry_msgs::wrenchstamped #'send self :rtmros-force-sensor-callback x :groupname groupname) (ros::subscribe (format nil "/off_~A" (string-downcase x)) geometry_msgs::wrenchstamped #'send self :rtmros-force-sensor-callback (read-from-string (format nil ":off-~A" (string-downcase x))) :groupname groupname) (ros::subscribe (format nil "/ref_~A" (string-downcase x)) geometry_msgs::wrenchstamped #'send self :rtmros-force-sensor-callback (read-from-string (format nil ":reference-~A" (string-downcase x))) :groupname groupname)) (send-all (send robot :force-sensors) :name)) (ros::subscribe "/zmp" geometry_msgs::pointstamped #'send self :rtmros-zmp-callback :groupname groupname) (ros::subscribe "/imu" sensor_msgs::imu #'send self :rtmros-imu-callback :groupname groupname) (ros::subscribe "/emergency_mode" std_msgs::int32 #'send self :rtmros-emergency-mode-callback :groupname groupname) (mapcar #'(lambda (x) (ros::subscribe (format nil "/~A_capture_point" x) geometry_msgs::pointstamped #'send self :rtmros-capture-point-callback (read-from-string (format nil ":~A-capture-point" x)) :groupname groupname)) '(ref act)) (mapcar #'(lambda (x) (ros::subscribe (format nil "/~A_contact_states" x) hrpsys_ros_bridge::contactstatesstamped #'send self :rtmros-contact-states-callback (read-from-string (format nil ":~A-contact-states" x)) :groupname groupname)) '(ref act))) #:prog12724)
  11: at (prog1 (send-super* :init args) (send self :define-all-rosbridge-srv-methods) (ros::subscribe "/motor_states" hrpsys_ros_bridge::motorstates #'send self :rtmros-motor-states-callback :groupname groupname) (mapcar #'(lambda (x) (ros::subscribe (format nil "/~A" (string-downcase x)) geometry_msgs::wrenchstamped #'send self :rtmros-force-sensor-callback x :groupname groupname) (ros::subscribe (format nil "/off_~A" (string-downcase x)) geometry_msgs::wrenchstamped #'send self :rtmros-force-sensor-callback (read-from-string (format nil ":off-~A" (string-downcase x))) :groupname groupname) (ros::subscribe (format nil "/ref_~A" (string-downcase x)) geometry_msgs::wrenchstamped #'send self :rtmros-force-sensor-callback (read-from-string (format nil ":reference-~A" (string-downcase x))) :groupname groupname)) (send-all (send robot :force-sensors) :name)) (ros::subscribe "/zmp" geometry_msgs::pointstamped #'send self :rtmros-zmp-callback :groupname groupname) (ros::subscribe "/imu" sensor_msgs::imu #'send self :rtmros-imu-callback :groupname groupname) (ros::subscribe "/emergency_mode" std_msgs::int32 #'send self :rtmros-emergency-mode-callback :groupname groupname) (mapcar #'(lambda (x) (ros::subscribe (format nil "/~A_capture_point" x) geometry_msgs::pointstamped #'send self :rtmros-capture-point-callback (read-from-string (format nil ":~A-capture-point" x)) :groupname groupname)) '(ref act)) (mapcar #'(lambda (x) (ros::subscribe (format nil "/~A_contact_states" x) hrpsys_ros_bridge::contactstatesstamped #'send self :rtmros-contact-states-callback (read-from-string (format nil ":~A-contact-states" x)) :groupname groupname)) '(ref act)))
  12: at (apply #'send-message self (class . super) :init :joint-states-queue-size 2 :robot hironxjsk-robot args)
  13: at (apply #'send-message self (class . super) :init :joint-states-queue-size 2 :robot hironxjsk-robot args)
  14: at (apply #'send-message self (class . super) :init :joint-states-queue-size 2 :robot hironxjsk-robot args)
  15: at (send-super* :init :joint-states-queue-size 2 :robot hironxjsk-robot args)
  16: at (let ((#:prog12723 (send-super* :init :joint-states-queue-size 2 :robot hironxjsk-robot args))) (progn (dolist (limb '(:rarm :larm :head :torso)) (send self :def-limb-controller-method limb) (send self :add-controller (read-from-string (format nil "~A-controller" limb)) :joint-enable-check t :create-actions t)) (setq hand-servo-num 4)) #:prog12723)
  17: at (prog1 (send-super* :init :joint-states-queue-size 2 :robot hironxjsk-robot args) (dolist (limb '(:rarm :larm :head :torso)) (send self :def-limb-controller-method limb) (send self :add-controller (read-from-string (format nil "~A-controller" limb)) :joint-enable-check t :create-actions t)) (setq hand-servo-num 4))
  18: at (apply #'send #:inst2722 :init args)
  19: at (apply #'send #:inst2722 :init args)
  And more...
/opt/ros/kinetic/share/euslisp/jskeus/eus/Linux64/bin/irteusgl 0 error: cannot find method :rarm-controller in (send self ctype)
```
This is because partial controllers are not defined before `*ri*` initialization.
We usually use `:def-limb-controller-method` to define partial controllers (e.g., [here](https://github.com/start-jsk/rtmros_tutorials/blob/34cd4d03556a6630c8e89058a24c96edd779edaa/hrpsys_ros_bridge_tutorials/euslisp/hrp2jsknts-interface.l#L18) and [here](https://github.com/start-jsk/rtmros_tutorials/blob/34cd4d03556a6630c8e89058a24c96edd779edaa/hrpsys_ros_bridge_tutorials/euslisp/hironxjsk-interface.l#L21)), but `:def-limb-controller-method` cannot be used before `*ri*` initialization because it uses `robot` slot of `*ri*`:
https://github.com/start-jsk/rtmros_common/blob/1.4.3/hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l#L317
```
$ roseus hironxjsk-interface.l 
configuring by "/opt/ros/kinetic/share/euslisp/jskeus/eus//lib/eusrt.l"
;; readmacro ;; object ;; packsym ;; common ;; constants ;; stream ;; string ;; loader ;; pprint ;; process ;; hashtab ;; array ;; mathtran ;; eusdebug ;; eusforeign ;; extnum ;; coordinates ;; tty ;; history ;; toplevel ;; trans ;; comp ;; builtins ;; par ;; intersection ;; geoclasses ;; geopack ;; geobody ;; primt ;; compose ;; polygon ;; viewing ;; viewport ;; viewsurface ;; hid ;; shadow ;; bodyrel ;; dda ;; helpsub ;; eushelp ;; xforeign ;; Xdecl ;; Xgraphics ;; Xcolor ;; Xeus ;; Xevent ;; Xpanel ;; Xitem ;; Xtext ;; Xmenu ;; Xscroll ;; Xcanvas ;; Xtop ;; Xapplwin 
connected to Xserver DISPLAY=:0
X events are being asynchronously monitored.
;; pixword ;; RGBHLS ;; convolve ;; piximage ;; pbmfile ;; image_correlation ;; oglforeign ;; gldecl ;; glconst ;; glforeign ;; gluconst ;; gluforeign ;; glxconst ;; glxforeign ;; eglforeign ;; eglfunc ;; glutil ;; gltexture ;; glprim ;; gleus ;; glview ;; toiv-undefined ;; fstringdouble irtmath irtutil irtc irtgeoc irtgraph ___time ___pgsql irtgeo euspqp pqp irtscene irtmodel irtdyna irtrobot irtsensor irtbvh irtcollada irtpointcloud irtx eusjpeg euspng png irtimage irtglrgb 
;; extending gcstack 0x60269d0[16374] --> 0x64abac0[32748] top=3d66
irtgl irtglc irtviewer 
EusLisp 9.27( 1.2.1) for Linux64 created on ip-172-30-1-63(Wed Feb 19 14:11:11 UTC 2020)
roseus ;; loading roseus("1.7.4") on euslisp((9.27 ip-172-30-1-63 Wed Feb 19 14:11:11 UTC 2020  1.2.1))
eustf roseus_c_util 
;; extending gcstack 0x64abac0[32738] --> 0x73b3ed0[65476] top=7ec4
1.irteusgl$ (instance hironxjsk-interface :def-limb-controller-method :rarm)
Call Stack (max depth: 20):
  0: at (send robot limb :joint-list)
  1: at (send-all (send robot limb :joint-list) :name)
  2: at (append (send-all (send robot limb :joint-list) :name) nil)
  3: at (cons 'list (append (send-all (send robot limb :joint-list) :name) nil))
  4: at (list (cons 'list (append (send-all (send robot limb :joint-list) :name) nil)))
  5: at (cons ':joint-names (list (cons 'list (append (send-all (send robot limb :joint-list) :name) nil))))
  6: at (cons 'cons (cons ':joint-names (list (cons 'list (append (send-all (send robot limb :joint-list) :name) nil)))))
  7: at (list (cons 'cons (cons ':joint-names (list (cons 'list (append (send-all (send robot limb :joint-list) :name) nil))))))
  8: at (cons (cons 'cons (cons ':action-type (list 'control_msgs::followjointtrajectoryaction))) (list (cons 'cons (cons ':joint-names (list (cons 'list (append (send-all (send robot limb :joint-list) :name) nil)))))))
  9: at (cons (cons 'cons (cons ':controller-state (list (format nil "~A_controller/state" (string-downcase limb))))) (cons (cons 'cons (cons ':action-type (list 'control_msgs::followjointtrajectoryaction))) (list (cons 'cons (cons ':joint-names (list (cons 'list (append (send-all (send robot limb :joint-list) :name) nil))))))))
  10: at (cons (cons 'cons (cons ':controller-action (list (format nil "~A_controller/follow_joint_trajectory_action" (string-downcase limb))))) (cons (cons 'cons (cons ':controller-state (list (format nil "~A_controller/state" (string-downcase limb))))) (cons (cons 'cons (cons ':action-type (list 'control_msgs::followjointtrajectoryaction))) (list (cons 'cons (cons ':joint-names (list (cons 'list (append (send-all (send robot limb :joint-list) :name) nil)))))))))
  11: at (cons (cons 'cons (cons ':group-name (list (string-downcase limb)))) (cons (cons 'cons (cons ':controller-action (list (format nil "~A_controller/follow_joint_trajectory_action" (string-downcase limb))))) (cons (cons 'cons (cons ':controller-state (list (format nil "~A_controller/state" (string-downcase limb))))) (cons (cons 'cons (cons ':action-type (list 'control_msgs::followjointtrajectoryaction))) (list (cons 'cons (cons ':joint-names (list (cons 'list (append (send-all (send robot limb :joint-list) :name) nil))))))))))
  12: at (cons 'list (cons (cons 'cons (cons ':group-name (list (string-downcase limb)))) (cons (cons 'cons (cons ':controller-action (list (format nil "~A_controller/follow_joint_trajectory_action" (string-downcase limb))))) (cons (cons 'cons (cons ':controller-state (list (format nil "~A_controller/state" (string-downcase limb))))) (cons (cons 'cons (cons ':action-type (list 'control_msgs::followjointtrajectoryaction))) (list (cons 'cons (cons ':joint-names (list (cons 'list (append (send-all (send robot limb :joint-list) :name) nil)))))))))))
  13: at (list (cons 'list (cons (cons 'cons (cons ':group-name (list (string-downcase limb)))) (cons (cons 'cons (cons ':controller-action (list (format nil "~A_controller/follow_joint_trajectory_action" (string-downcase limb))))) (cons (cons 'cons (cons ':controller-state (list (format nil "~A_controller/state" (string-downcase limb))))) (cons (cons 'cons (cons ':action-type (list 'control_msgs::followjointtrajectoryaction))) (list (cons 'cons (cons ':joint-names (list (cons 'list (append (send-all (send robot limb :joint-list) :name) nil))))))))))))
  14: at (cons 'list (list (cons 'list (cons (cons 'cons (cons ':group-name (list (string-downcase limb)))) (cons (cons 'cons (cons ':controller-action (list (format nil "~A_controller/follow_joint_trajectory_action" (string-downcase limb))))) (cons (cons 'cons (cons ':controller-state (list (format nil "~A_controller/state" (string-downcase limb))))) (cons (cons 'cons (cons ':action-type (list 'control_msgs::followjointtrajectoryaction))) (list (cons 'cons (cons ':joint-names (list (cons 'list (append (send-all (send robot limb :joint-list) :name) nil)))))))))))))
  15: at (list (cons 'list (list (cons 'list (cons (cons 'cons (cons ':group-name (list (string-downcase limb)))) (cons (cons 'cons (cons ':controller-action (list (format nil "~A_controller/follow_joint_trajectory_action" (string-downcase limb))))) (cons (cons 'cons (cons ':controller-state (list (format nil "~A_controller/state" (string-downcase limb))))) (cons (cons 'cons (cons ':action-type (list 'control_msgs::followjointtrajectoryaction))) (list (cons 'cons (cons ':joint-names (list (cons 'list (append (send-all (send robot limb :joint-list) :name) nil))))))))))))))
  16: at (cons 'nil (list (cons 'list (list (cons 'list (cons (cons 'cons (cons ':group-name (list (string-downcase limb)))) (cons (cons 'cons (cons ':controller-action (list (format nil "~A_controller/follow_joint_trajectory_action" (string-downcase limb))))) (cons (cons 'cons (cons ':controller-state (list (format nil "~A_controller/state" (string-downcase limb))))) (cons (cons 'cons (cons ':action-type (list 'control_msgs::followjointtrajectoryaction))) (list (cons 'cons (cons ':joint-names (list (cons 'list (append (send-all (send robot limb :joint-list) :name) nil)))))))))))))))
  17: at (cons (read-from-string (format nil "~A-controller" limb)) (cons 'nil (list (cons 'list (list (cons 'list (cons (cons 'cons (cons ':group-name (list (string-downcase limb)))) (cons (cons 'cons (cons ':controller-action (list (format nil "~A_controller/follow_joint_trajectory_action" (string-downcase limb))))) (cons (cons 'cons (cons ':controller-state (list (format nil "~A_controller/state" (string-downcase limb))))) (cons (cons 'cons (cons ':action-type (list 'control_msgs::followjointtrajectoryaction))) (list (cons 'cons (cons ':joint-names (list (cons 'list (append (send-all (send robot limb :joint-list) :name) nil))))))))))))))))
  18: at (list (cons (read-from-string (format nil "~A-controller" limb)) (cons 'nil (list (cons 'list (list (cons 'list (cons (cons 'cons (cons ':group-name (list (string-downcase limb)))) (cons (cons 'cons (cons ':controller-action (list (format nil "~A_controller/follow_joint_trajectory_action" (string-downcase limb))))) (cons (cons 'cons (cons ':controller-state (list (format nil "~A_controller/state" (string-downcase limb))))) (cons (cons 'cons (cons ':action-type (list 'control_msgs::followjointtrajectoryaction))) (list (cons 'cons (cons ':joint-names (list (cons 'list (append (send-all (send robot limb :joint-list) :name) nil)))))))))))))))))
  19: at (cons (send (class self) :name) (list (cons (read-from-string (format nil "~A-controller" limb)) (cons 'nil (list (cons 'list (list (cons 'list (cons (cons 'cons (cons ':group-name (list (string-downcase limb)))) (cons (cons 'cons (cons ':controller-action (list (format nil "~A_controller/follow_joint_trajectory_action" (string-downcase limb))))) (cons (cons 'cons (cons ':controller-state (list (format nil "~A_controller/state" (string-downcase limb))))) (cons (cons 'cons (cons ':action-type (list 'control_msgs::followjointtrajectoryaction))) (list (cons 'cons (cons ':joint-names (list (cons 'list (append (send-all (send robot limb :joint-list) :name) nil))))))))))))))))))
  And more...
/opt/ros/kinetic/share/euslisp/jskeus/eus/Linux64/bin/irteusgl 0 error: cannot find method :rarm in (send robot limb :joint-list)
```

## Solution

This PR fixes the above problem by avoiding evalution of `robot` when `:def-limb-controller-method` is called.