### PR TITLE
Minor fixes to follow melodic release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,6 @@ matrix:
   - env: USE_JENKINS=true ROS_DISTRO=hydro  USE_DEB=false   EXTRA_DEB="ros-hydro-hrpsys-ros-bridge ros-hydro-pr2eus" ROS_PARALLEL_JOBS="-j1 -l1" NOT_TEST_INSTALL=true IS_EUSLISP_TRAVIS_TEST="true"
   # Running euslisp test on travis often takes more than 50 min
   - env: USE_TRAVIS=true ROS_DISTRO=indigo USE_DEB=true   EXTRA_DEB="ros-indigo-hrpsys-ros-bridge ros-indigo-pr2eus" NOT_TEST_INSTALL=true TEST_PKGS="hrpsys_ros_bridge" IS_EUSLISP_TRAVIS_TEST=true
-  - env: USE_JENKINS=true ROS_DISTRO=melodic USE_DEB=true
 notifications:
   email:
     recipients:

--- a/README.md
+++ b/README.md
@@ -11,8 +11,6 @@ This document explains how to use and how to contribute to rtm-ros-robotics soft
  rtm-ros-robotics software is distributed as ros-debian packages, if you already use ROS system, install the software as follows:
  - `sudo apt-get install ros-${ROS_DISTRO}-rtmros-common`
 
- **NOTE** Currently, those packages are not released to `melodic` distribution. Please compile all rtm-ros-robotics source code by following the section below ("2. Compile from source code").
-
  If you did not install ROS system, please follow [this instruction](http://wiki.ros.org/ROS/Installation).
  - ``sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu `lsb_release -a` main" > /etc/apt/sources.list.d/ros-latest.list'``
  - `wget http://packages.ros.org/ros.key -O - | sudo apt-key add -`
@@ -24,8 +22,8 @@ This document explains how to use and how to contribute to rtm-ros-robotics soft
 
 2. Compile from source code
 
- You may have two choices, one is to compile target repository (rtmros_common) only, the other is to compile all rtm-ros-robotics source code.
- First, create catkin workspace and add rtmros_common:
+ You may have two choices, one is to compile target repository (`rtmros_common`) only, the other is to compile all rtm-ros-robotics source code.
+ First, create catkin workspace and add the target repository (`rtmros_common`):
  - `mkdir -p ~/catkin_ws/src`
  - `cd ~/catkin_ws/src`
  - `wstool init .`


### PR DESCRIPTION
Melodic rtmros_common is now released to http://packages.ros.org/ros/ubuntu/, so...
- Remove description special for melodic from README
- Remove `ROS_DISTRO=melodic USE_DEB=true` from `allow_failures` in .travis.yml

I also fixed README a little.