### PR TITLE
[HrpsysSeqStateROSBridge] publish gain in motor_states

### DIFF
--- a/hrpsys_ros_bridge/launch/hrpsys_ros_bridge.launch
+++ b/hrpsys_ros_bridge/launch/hrpsys_ros_bridge.launch
@@ -143,6 +143,10 @@
           output="screen" args ="$(arg openrtm_args)" />
     <rtconnect from="RobotHardwareServiceROSBridge.rtc:RobotHardwareService" to="$(arg SIMULATOR_NAME).rtc:RobotHardwareService"  subscription_type="new"/>
     <rtconnect from="$(arg SIMULATOR_NAME).rtc:servoState" to="HrpsysSeqStateROSBridge0.rtc:servoState" subscription_type="$(arg subscription_type)" push_policy="$(arg push_policy)" push_rate="$(arg push_rate)" buffer_length="$(arg buffer_length)" unless="$(arg USE_SOFTERRORLIMIT)"/>
+    <rtconnect from="$(arg SIMULATOR_NAME).rtc:pgain" to="HrpsysSeqStateROSBridge0.rtc:pgain" subscription_type="$(arg subscription_type)" push_policy="$(arg push_policy)" push_rate="$(arg push_rate)" buffer_length="$(arg buffer_length)"/>
+    <rtconnect from="$(arg SIMULATOR_NAME).rtc:dgain" to="HrpsysSeqStateROSBridge0.rtc:dgain" subscription_type="$(arg subscription_type)" push_policy="$(arg push_policy)" push_rate="$(arg push_rate)" buffer_length="$(arg buffer_length)"/>
+    <rtconnect from="$(arg SIMULATOR_NAME).rtc:torquePgain" to="HrpsysSeqStateROSBridge0.rtc:torquePgain" subscription_type="$(arg subscription_type)" push_policy="$(arg push_policy)" push_rate="$(arg push_rate)" buffer_length="$(arg buffer_length)"/>
+    <rtconnect from="$(arg SIMULATOR_NAME).rtc:torqueDgain" to="HrpsysSeqStateROSBridge0.rtc:torqueDgain" subscription_type="$(arg subscription_type)" push_policy="$(arg push_policy)" push_rate="$(arg push_rate)" buffer_length="$(arg buffer_length)"/>
     <rtactivate component="RobotHardwareServiceROSBridge.rtc" />
   </group>
 

--- a/hrpsys_ros_bridge/msg/MotorStates.msg
+++ b/hrpsys_ros_bridge/msg/MotorStates.msg
@@ -38,5 +38,9 @@ bool[] power_state
 int32[] servo_alarm
 int16[] driver_temp
 float64[] temperature
+float64[] pgain
+float64[] dgain
+float64[] torque_pgain
+float64[] torque_dgain
 std_msgs/Float64MultiArray extra_data
 

--- a/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.cpp
+++ b/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.cpp
@@ -382,6 +382,29 @@ RTC::ReturnCode_t HrpsysSeqStateROSBridge::onExecute(RTC::UniqueId ec_id)
             mot_states.extra_data.data[i*extra_size+j] = ((float *)&(m_servoState.data[i][1]))[j];
         }
       }
+
+      // pgainIn dgainIn torquePgainIn torqueDgainIn
+      if ( m_pgainIn.isNew () ) m_pgainIn.read();
+      if ( m_pgain.data.length() == joint_size){
+        mot_states.pgain.resize(joint_size);
+        for ( unsigned int i = 0; i < joint_size ; i++ ) mot_states.pgain[i] = m_pgain.data[i];
+      }
+      if ( m_dgainIn.isNew () ) m_dgainIn.read();
+      if ( m_dgain.data.length() == joint_size){
+        mot_states.dgain.resize(joint_size);
+        for ( unsigned int i = 0; i < joint_size ; i++ ) mot_states.dgain[i] = m_dgain.data[i];
+      }
+      if ( m_torquePgainIn.isNew () ) m_torquePgainIn.read();
+      if ( m_torquePgain.data.length() == joint_size){
+        mot_states.torque_pgain.resize(joint_size);
+        for ( unsigned int i = 0; i < joint_size ; i++ ) mot_states.torque_pgain[i] = m_torquePgain.data[i];
+      }
+      if ( m_torqueDgainIn.isNew () ) m_torqueDgainIn.read();
+      if ( m_torqueDgain.data.length() == joint_size){
+        mot_states.torque_dgain.resize(joint_size);
+        for ( unsigned int i = 0; i < joint_size ; i++ ) mot_states.torque_dgain[i] = m_torqueDgain.data[i];
+      }
+
       mot_states_pub.publish(mot_states);
     }
     catch(const std::runtime_error &e)

--- a/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridgeImpl.cpp
+++ b/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridgeImpl.cpp
@@ -36,6 +36,10 @@ HrpsysSeqStateROSBridgeImpl::HrpsysSeqStateROSBridgeImpl(RTC::Manager* manager)
     m_rsvelIn("rsvel", m_rsvel),
     m_rstorqueIn("rstorque", m_rstorque),
     m_servoStateIn("servoState", m_servoState),
+    m_pgainIn("pgain", m_pgain),
+    m_dgainIn("dgain", m_dgain),
+    m_torquePgainIn("torquePgain", m_torquePgain),
+    m_torqueDgainIn("torqueDgain", m_torqueDgain),
     m_rszmpIn("rszmp", m_rszmp),
     m_rsrefCPIn("rsrefCapturePoint", m_rsrefCP),
     m_rsactCPIn("rsactCapturePoint", m_rsactCP),
@@ -71,6 +75,10 @@ RTC::ReturnCode_t HrpsysSeqStateROSBridgeImpl::onInitialize()
   addInPort("rsrefCapturePoint", m_rsrefCPIn);
   addInPort("rsactCapturePoint", m_rsactCPIn);
   addInPort("servoState", m_servoStateIn);
+  addInPort("pgain", m_pgainIn);
+  addInPort("dgain", m_dgainIn);
+  addInPort("torquePgain", m_torquePgainIn);
+  addInPort("torqueDgain", m_torqueDgainIn);
   addInPort("rsCOPInfo", m_rsCOPInfoIn);
   addInPort("emergencyMode", m_emergencyModeIn);
   addInPort("refContactStates", m_refContactStatesIn);

--- a/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridgeImpl.h
+++ b/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridgeImpl.h
@@ -143,6 +143,14 @@ class HrpsysSeqStateROSBridgeImpl  : public RTC::DataFlowComponentBase
   InPort<TimedDoubleSeq> m_rstorqueIn;
   OpenHRP::TimedLongSeqSeq m_servoState;
   InPort<OpenHRP::TimedLongSeqSeq> m_servoStateIn;
+  TimedDoubleSeq m_pgain;
+  InPort<TimedDoubleSeq> m_pgainIn;
+  TimedDoubleSeq m_dgain;
+  InPort<TimedDoubleSeq> m_dgainIn;
+  TimedDoubleSeq m_torquePgain;
+  InPort<TimedDoubleSeq> m_torquePgainIn;
+  TimedDoubleSeq m_torqueDgain;
+  InPort<TimedDoubleSeq> m_torqueDgainIn;
   TimedPoint3D m_rszmp;
   InPort<TimedPoint3D> m_rszmpIn;
   TimedPoint3D m_rsrefCP;


### PR DESCRIPTION
https://github.com/fkanehiro/hrpsys-base/pull/1295 が必要です。

これまで現在の関節ゲインの値をROSのレイヤで知る方法が無かったため、
`MotorStates` トピック型に関節ゲインに関する情報(`pgain` `dgain` `torque_pgain` `torque_dgain`)を追加し、
HrpsysSeqStateROSBridgeが`motor_states`トピックで現在の関節ゲインの値を追加で出力するようにしました。
