### PR TITLE
[rtm-ros-robot-interface.l]fix bug in :cmd-vel-cb

### DIFF
--- a/hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l
+++ b/hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l
@@ -1647,7 +1647,7 @@
    (send self :go-velocity
 	 (* vel-x-ratio (send (send msg :linear) :x))
          (* vel-y-ratio (send (send msg :linear) :y))
-         (* vel-th-ratio (send (send msg :angular) :z)))
+         (* vel-th-ratio (rad2deg (send (send msg :angular) :z))))
    )
   (:cmd-vel-mode
    ()

--- a/hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l
+++ b/hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l
@@ -1461,7 +1461,7 @@
      ))
   (:go-velocity
    (vx vy vth)
-   "Call goVelocity."
+   "Call goVelocity. vx[m/s], vy[m/s], and vth[deg/s]"
    (send self :autobalancerservice_goVelocity :vx vx :vy vy :vth vth))
   (:go-stop
    ()

--- a/hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l
+++ b/hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l
@@ -1653,8 +1653,8 @@
    ()
    "Walk with subscribing /cmd_vel topic."
    (send self :start-cmd-vel-mode)
+   (send self :go-velocity 0 0 0)
    (do-until-key
-    (send self :go-velocity 0 0 0)
     (ros::spin-once)
     (ros::sleep)
     )


### PR DESCRIPTION
This Pull Request fixes a bug in `:cmd-vel-cb` of `rtm-ros-robot-interface`.

The unit of AutoBlancerService::goVelocity is `deg/s`, not `rad/s`
https://github.com/fkanehiro/hrpsys-base/blob/e98cf26c12eeeda761cef5b836e9640d68bf7387/idl/AutoBalancerService.idl#L345
