### PR TITLE
[controller_config_converter.py] add rhand lhand limbs

### DIFF
--- a/hrpsys_ros_bridge/scripts/controller_config_converter.py
+++ b/hrpsys_ros_bridge/scripts/controller_config_converter.py
@@ -33,6 +33,8 @@ if __name__ == '__main__':
     lst = yaml.load(open(inputfile).read())
 
     limb_candidates = ('larm', 'rarm', 'lleg', 'rleg', 'torso', 'head') ## candidates of limb names
+    if "limbs" in lst.keys():
+        limb_candidates = lst["limbs"]
 
     invalid_yaml = True
     for l in lst.keys():


### PR DESCRIPTION
(controller_config_converter.pyは，`[robot_name].yaml`を読み込んで，`[robot_name]_controller_config`を作成するプログラムです．)
`rhand_controller`と`lhand_controller`を作成することができるようにしました．

副作用はありません．