### PR TITLE
[hrpsys_ros_bridge/test] remove reverse for samplerobot force-sensors

### DIFF
--- a/hrpsys_ros_bridge/test/hrpsys-samples/samplerobot-sequence-player.l
+++ b/hrpsys_ros_bridge/test/hrpsys-samples/samplerobot-sequence-player.l
@@ -100,7 +100,7 @@
                   (dif-root-pos (distance (get-float-vector-from-log "/tmp/test-samplerobot-seq-full.sh_basePosOut") ref-root-pos))
                   (dif-root-rpy (distance (get-float-vector-from-log "/tmp/test-samplerobot-seq-full.sh_baseRpyOut") ref-root-rpy))
                   (dif-zmp (distance (get-float-vector-from-log "/tmp/test-samplerobot-seq-full.sh_zmpOut") ref-zmp))
-                  (dif-wrench (distance (apply #'concatenate float-vector (mapcar #'(lambda (x) (get-float-vector-from-log (format nil "/tmp/test-samplerobot-seq-full.sh_~AOut" x))) (reverse (send-all (send *sr* :force-sensors) :name)))) ;;(reverse) Because :force-sensors and end-effectors of hrpsys are in reverse order.
+                  (dif-wrench (distance (apply #'concatenate float-vector (mapcar #'(lambda (x) (get-float-vector-from-log (format nil "/tmp/test-samplerobot-seq-full.sh_~AOut" x))) (send-all (send *sr* :force-sensors) :name)))
                                         ref-wrench)))
               (warn ";; Diff angle-vector = ~A, root-pos = ~A, root-rpy = ~A, zmp = ~A, wrench = ~A~%"
                     dif-angle-vector dif-root-pos dif-root-rpy dif-zmp dif-wrench)


### PR DESCRIPTION
https://github.com/jsk-ros-pkg/jsk_model_tools/pull/236 のrelease後にmergeしてください.

euscolladaのバグに対応するためのテンポラリの修正としてhttps://github.com/start-jsk/rtmros_common/pull/1080#issuecomment-561094288 https://github.com/start-jsk/rtmros_common/pull/1081 でテストに施された変更を、該当のバグがhttps://github.com/jsk-ros-pkg/jsk_model_tools/pull/236 で修正されるため、戻します。