### PR TITLE
[openrtm_tools/rtmlaunch.py] add ec_index attribute to rtactivate tag

### DIFF
--- a/openrtm_tools/src/openrtm_tools/rtmlaunch.py
+++ b/openrtm_tools/src/openrtm_tools/rtmlaunch.py
@@ -179,8 +179,12 @@ def rtactivate(nameserver, tags, tree):
         except Exception, e:
             print >>sys.stderr, '\033[31m[rtmlaunch] Could not Activate (', cmd_path, ') : ', e,'\033[0m'
             return 1
+        if tag.attributes.get("ec_index") != None:
+            ec_index = int(tag.attributes.get("ec_index").value);
+        else:
+            ec_index = 0
         try:
-            options = optparse.Values({"ec_index": 0, 'verbose': False})
+            options = optparse.Values({"ec_index": ec_index, 'verbose': False})
             try :
                 state_control_base.alter_component_state(activate_action, cmd_path, full_path, options, tree=tree)
             except Exception, e: # openrtm 1.1.0


### PR DESCRIPTION
`rtmlaunch.py`で読み込むlaunchファイルの`<rtactivate>`タグに、`ec_index`attributeを追加しました.

現在の`<rtactivate>`タグは、RTCの実行コンテキストのidがデフォルトの0でないとアクティベートすることができません。`hrpsys_config.py`などで1つの実行コンテキストのもとで複数のRTCを走らせるようにすると、それらのRTCの実行コンテキストのidがデフォルトの0ではない場合があります. そのような場合でも`<rtactivate>`タグが使いたいというケースがあったので、attributeで実行コンテキストのidを指定できるようにする必要がありました。

デフォルトの挙動は変わりません.


(実行コンテキストのidが常にデフォルトの0とは限らないという例)
```bash
 rtmlaunch  hrpsys_ros_bridge samplerobot.launch
```
```bash
$ rtcat localhost:15005/seq.rtc
seq.rtc  Active
(略)
$ rtdeact localhost:15005/seq.rtc # id 0の実行コンテキストを停止する
$ rtcat localhost:15005/seq.rtc # 停止しない
seq.rtc  Active
(略)
$ rtdeact localhost:15005/seq.rtc -e 1 # id 1の実行コンテキストを停止する
$ rtcat localhost:15005/seq.rtc # 停止する
seq.rtc  Inactive
(略)
$ 
```