### PR TITLE
[HrpsysSeqStateROSBridge.cpp] avoid segmentation fault when unkown joint name is given to /fullbody_controller/follow_joint_trajectory_action/goal

### DIFF
--- a/hrpsys_ros_bridge/src/HrpsysJointTrajectoryBridge.cpp
+++ b/hrpsys_ros_bridge/src/HrpsysJointTrajectoryBridge.cpp
@@ -457,7 +457,9 @@ void HrpsysJointTrajectoryBridge::jointTrajectoryActionObj::onJointTrajectory(
     trajectory_msgs::JointTrajectoryPoint point = trajectory.points[i];
     for (unsigned int j = 0; j < joint_names.size(); j++)
     {
-      parent->body->link(joint_names[j])->q = point.positions[j];
+      hrp::Link* l = parent->body->link(joint_names[j]);
+      if(l) l->q = point.positions[j];
+      else ROS_WARN_STREAM_ONCE("[" << parent->getInstanceName() << "] @onJointTrajectoryAction (" << this->groupname << ") : joint named " << joint_names[j] << " is not found. Skipping ...");
     }
 
     parent->body->calcForwardKinematics();

--- a/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.cpp
+++ b/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.cpp
@@ -190,6 +190,7 @@ void HrpsysSeqStateROSBridge::onJointTrajectory(trajectory_msgs::JointTrajectory
     for (unsigned int j=0; j < trajectory.joint_names.size(); j++ ) {
       hrp::Link* l = body->link(joint_names[j]);
       if(l) l->q = point.positions[j];
+      else ROS_WARN_STREAM_ONCE("[" << getInstanceName() << "] @onJointTrajectoryAction : joint named " << joint_names[j] << " is not found. Skipping ...");
     }
 
     body->calcForwardKinematics();

--- a/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.cpp
+++ b/hrpsys_ros_bridge/src/HrpsysSeqStateROSBridge.cpp
@@ -188,7 +188,8 @@ void HrpsysSeqStateROSBridge::onJointTrajectory(trajectory_msgs::JointTrajectory
 
     trajectory_msgs::JointTrajectoryPoint point = trajectory.points[i];
     for (unsigned int j=0; j < trajectory.joint_names.size(); j++ ) {
-      body->link(joint_names[j])->q = point.positions[j];
+      hrp::Link* l = body->link(joint_names[j]);
+      if(l) l->q = point.positions[j];
     }
 
     body->calcForwardKinematics();


### PR DESCRIPTION
`/fullbody_controller/follow_joint_trajectory_action/goal` に、存在しない関節名が与えられるとHrpsysSeqStateROSBridgeがSegmentation Faultで落ちてしまいました。この問題を直すPull Requestです。

存在しない関節名が与えられても無視するようにして、Segmentation Faultで落ちないようにしました。

@Utaro-M のハンドの実験で必要です。