### PR TITLE
【auto-stabilizer】merge origin/master to auto-stabilizer

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule ".travis"]
 	path = .travis
-	url = git://github.com/jsk-ros-pkg/jsk_travis.git
+	url = https://github.com/jsk-ros-pkg/jsk_travis.git


### PR DESCRIPTION
(今後はauto-stabilizerブランチの開発はhttps://github.com/YutaKojio/rtmros_common/tree/auto-stabilizer ではなくhttps://github.com/start-jsk/rtmros_common/tree/auto-stabilizer で行います。)

auto-stabilizerブランチでwstool updateをしたときに、
```
[rtm-ros-robotics/rtmros_common] Fetching https://github.com/YutaKojio/rtmros_common.git (version auto-stabilizer) to /home/hiraoka/hiraoka_ws/autostabilizer_ws/src/rtm-ros-robotics/rtmros_common
Cloning into '/home/hiraoka/hiraoka_ws/autostabilizer_ws/src/rtm-ros-robotics/rtmros_common'...
remote: Enumerating objects: 21765, done.
remote: Counting objects: 100% (174/174), done.
remote: Compressing objects: 100% (92/92), done.
remote: Total 21765 (delta 106), reused 126 (delta 81), pack-reused 21591
Receiving objects: 100% (21765/21765), 13.79 MiB | 9.58 MiB/s, done.
Resolving deltas: 100% (15641/15641), done.
```
の状態で止まってしまうという問題がありました。

最近masterにmergeされたhttps://github.com/start-jsk/rtmros_common/pull/1118 によって直ることが知られているため、auto-stabilizerブランチにも最新のmasterをmergeします。