### PR TITLE
[hrpsys_tools/hrpsys.launch] enable to change hrpsys_periodic_type argument

### DIFF
--- a/hrpsys_tools/launch/hrpsys.launch
+++ b/hrpsys_tools/launch/hrpsys.launch
@@ -41,14 +41,14 @@
   <!-- see http://code.google.com/p/hrpsys-base/issues/detail?id=14 for  exec_cxt.periodic.rate:100000 -->
   <arg unless="$(arg USE_RTCD)" name="hrpsys_precreate_rtc" default="HGcontroller"/>
   <arg unless="$(arg USE_RTCD)" name="hrpsys_preload_rtc" default="$(arg hrpsys_precreate_rtc).so"/>
-  <arg unless="$(arg USE_RTCD)" name="hrpsys_periodic_type" value="SynchExtTriggerEC" />
+  <arg unless="$(arg USE_RTCD)" name="hrpsys_periodic_type" default="SynchExtTriggerEC" />
   <arg unless="$(arg REALTIME)" name="hrpsys_opt_args" value="-endless " />
   <arg unless="$(arg GUI)" name="hrpsys_gui_args" value="-nodisplay" />
   <!--   for rtcd -->
   <arg     if="$(arg USE_RTCD)" name="hrpsys_periodic_rate" default="200"/>
   <arg     if="$(arg USE_RTCD)" name="hrpsys_preload_rtc" default="RobotHardware.so,hrpEC.so"/>
   <arg     if="$(arg USE_RTCD)" name="hrpsys_precreate_rtc" default="RobotHardware"/>
-  <arg     if="$(arg USE_RTCD)" name="hrpsys_periodic_type" value="hrpExecutionContext" />
+  <arg     if="$(arg USE_RTCD)" name="hrpsys_periodic_type" default="hrpExecutionContext" />
   <arg     if="$(arg REALTIME)" name="hrpsys_opt_args" value="-endless -realtime" />
   <arg     if="$(arg GUI)" name="hrpsys_gui_args" value="" />
   <!--   for both -->


### PR DESCRIPTION
hrpsys_toolsのhrpsys.launchは、argument `hrpsys_periodic_type`が外部から与えられない仕様になっているため、デフォルトのExecutionContextではない独自のExecutionContextを使用することができませんでした。

デフォルトのhrpExecutionContextの代わりに、[シミュレーションの時間と同期をとるためのExecutionContext](https://github.com/Naoki-Hiraoka/execution_context_shmtime) を使いたいと思ったのですが、それができず不便でした。

`value`を`default`に変更することで、argument `hrpsys_periodic_type`を外部から与えられるようにしました。